### PR TITLE
Creates protected route

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,8 @@ import { Navbar } from './components/Navbar/Navbar';
 import Settings from './pages/Settings/Settings';
 import NotFound from './pages/NotFound/NotFound';
 
+import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
+
 function App(): JSX.Element {
   return (
     <ThemeProvider theme={theme}>
@@ -26,8 +28,8 @@ function App(): JSX.Element {
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
-                <Route exact path="/dashboard" component={Dashboard} />
-                <Route path="/profile/settings" component={Settings} />
+                <ProtectedRoute exact path="/dashboard" component={Dashboard} />
+                <ProtectedRoute path="/profile/settings" component={Settings} />
                 <Route path="*">
                   <NotFound />
                 </Route>

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -4,7 +4,7 @@ import { useSocket } from '../../context/useSocketContext';
 import CircularProgress from '@mui/material/CircularProgress';
 import { Route, Redirect, RouteProps, RouteComponentProps } from 'react-router-dom';
 
-const ProtectedRoute: React.FC<RouteProps> = ({ component, render, ...routeProps }) => {
+const ProtectedRoute = ({ component: Component, ...rest }: RouteProps) : JSX.Element  => {
   const { loggedInUser } = useAuth();
   const { initSocket } = useSocket();
 

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect } from 'react';
+import { useAuth } from '../../context/useAuthContext';
+import { useSocket } from '../../context/useSocketContext';
+import CircularProgress from '@mui/material/CircularProgress';
+import { Route, Redirect, RouteProps, RouteComponentProps } from 'react-router-dom';
+
+const ProtectedRoute: React.FC<RouteProps> = ({ component, render, ...routeProps }) => {
+  const { loggedInUser } = useAuth();
+  const { initSocket } = useSocket();
+
+  useEffect(() => {
+    initSocket();
+  }, [initSocket]);
+
+  if (loggedInUser === undefined) {
+    // show progress circule until we have some value for user
+    return <CircularProgress />;
+  }
+  if (!loggedInUser) {
+    // redirect if user is not authenticated
+    return (
+      <Redirect
+        to={{
+          pathname: '/login',
+          state: {
+            from: routeProps.location,
+          },
+        }}
+      />
+    );
+  }
+
+  return (
+    <Route
+      {...routeProps}
+      render={(props: RouteComponentProps) => {
+        if (loggedInUser) {
+          // render protected component on valid user
+          if (component) {
+            return React.createElement(component, props);
+          }
+          if (render) {
+            return render(props);
+          }
+        }
+      }}
+    />
+  );
+};
+
+export default ProtectedRoute;

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -31,7 +31,7 @@ const ProtectedRoute = ({ component: Component, ...rest }: RouteProps) : JSX.Ele
   }
 
   return (
-    <Route
+    return <Route {... rest} render={(props) => (loggedInUser ? <Component {...props} /> : <Redirect to="/login" />)} />;
       {...routeProps}
       render={(props: RouteComponentProps) => {
         if (loggedInUser) {

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,51 +1,20 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useAuth } from '../../context/useAuthContext';
-import { useSocket } from '../../context/useSocketContext';
 import CircularProgress from '@mui/material/CircularProgress';
-import { Route, Redirect, RouteProps, RouteComponentProps } from 'react-router-dom';
+import { Route, Redirect, RouteProps } from 'react-router-dom';
 
-const ProtectedRoute = ({ component: Component, ...rest }: RouteProps) : JSX.Element  => {
+interface ProtectedRouteProps extends RouteProps {
+  component: React.ComponentType<any>;
+}
+const ProtectedRoute = ({ component: Component, ...rest }: ProtectedRouteProps): JSX.Element => {
   const { loggedInUser } = useAuth();
-  const { initSocket } = useSocket();
-
-  useEffect(() => {
-    initSocket();
-  }, [initSocket]);
 
   if (loggedInUser === undefined) {
     // show progress circule until we have some value for user
     return <CircularProgress />;
   }
-  if (!loggedInUser) {
-    // redirect if user is not authenticated
-    return (
-      <Redirect
-        to={{
-          pathname: '/login',
-          state: {
-            from: routeProps.location,
-          },
-        }}
-      />
-    );
-  }
 
-  return (
-    return <Route {... rest} render={(props) => (loggedInUser ? <Component {...props} /> : <Redirect to="/login" />)} />;
-      {...routeProps}
-      render={(props: RouteComponentProps) => {
-        if (loggedInUser) {
-          // render protected component on valid user
-          if (component) {
-            return React.createElement(component, props);
-          }
-          if (render) {
-            return render(props);
-          }
-        }
-      }}
-    />
-  );
+  return <Route {...rest} render={(props) => (loggedInUser ? <Component {...props} /> : <Redirect to="/login" />)} />;
 };
 
 export default ProtectedRoute;

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -1,26 +1,8 @@
-import React, { useEffect } from 'react';
-import { useAuth } from '../../context/useAuthContext';
-import { useSocket } from '../../context/useSocketContext';
-import { useHistory } from 'react-router-dom';
-import { CircularProgress, Grid, Typography } from '@mui/material';
+import React from 'react';
+import { Grid, Typography } from '@mui/material';
 import PageContainer from '../../components/PageContainer/PageContainer';
 
 export default function Dashboard(): JSX.Element {
-  const { loggedInUser } = useAuth();
-  const { initSocket } = useSocket();
-  const history = useHistory();
-
-  useEffect(() => {
-    initSocket();
-  }, [initSocket]);
-
-  if (loggedInUser === undefined) return <CircularProgress />;
-  if (!loggedInUser) {
-    history.push('/login');
-    // loading for a split seconds until history.push works
-    return <CircularProgress />;
-  }
-
   return (
     <PageContainer>
       <Grid container>


### PR DESCRIPTION
### What this PR does (required):
- Adds new component to protect route
- Protects existing route that should be access by authenticated user

### Any information needed to test this feature (required):
- Visit `/dashboard` route
- Route should only be access if user is logged in

### Any issues with the current functionality (optional):
- If user try to access a protected page and is not logged in, page will redirect to `/dashboard` after login/signup no matter which page you try to access before coming to login/signup page
