### PR TITLE
Integrates profile photo settings

### DIFF
--- a/client/src/context/useAuthContext.tsx
+++ b/client/src/context/useAuthContext.tsx
@@ -31,7 +31,6 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
 
   const updateLoginContext = useCallback(
     (data: AuthApiDataSuccess) => {
-      console.log(data);
       setLoggedInUser(data.user);
       setLoggedInUserProfile(data.profile);
       if (data.user && (history.location.pathname === '/login' || history.location.pathname === '/signup')) {

--- a/client/src/context/useAuthContext.tsx
+++ b/client/src/context/useAuthContext.tsx
@@ -26,7 +26,7 @@ export const AuthContext = createContext<IAuthContext>({
 export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
   // default undefined before loading, once loaded provide user or null if logged out
   const [loggedInUser, setLoggedInUser] = useState<User | null | undefined>();
-  const [profile, setProfile] = useState<Profile | null | undefined>();
+  const [loggedInUserProfile, setLoggedInUserProfile] = useState<Profile | null | undefined>();
   const history = useHistory();
 
   const updateLoginContext = useCallback(

--- a/client/src/context/useAuthContext.tsx
+++ b/client/src/context/useAuthContext.tsx
@@ -8,7 +8,7 @@ import { ProfileApiDataSuccess } from '../interface/ProfileApiData';
 import { Profile } from '../interface/Profile';
 
 interface IAuthContext {
-  profile: any;
+  loggedInUserProfile: Profile | null | undefined;
   loggedInUser: User | null | undefined;
   updateLoginContext: (data: AuthApiDataSuccess) => void;
   updateProfileContext: (data: ProfileApiDataSuccess) => void;
@@ -16,7 +16,7 @@ interface IAuthContext {
 }
 
 export const AuthContext = createContext<IAuthContext>({
-  profile: undefined,
+  loggedInUserProfile: undefined,
   loggedInUser: undefined,
   updateLoginContext: () => null,
   updateProfileContext: () => null,
@@ -33,7 +33,7 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
     (data: AuthApiDataSuccess) => {
       console.log(data);
       setLoggedInUser(data.user);
-      setProfile(data.profile);
+      setLoggedInUserProfile(data.profile);
       if (data.user && (history.location.pathname === '/login' || history.location.pathname === '/signup')) {
         history.push('/dashboard');
       }
@@ -42,7 +42,7 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
   );
 
   const updateProfileContext = useCallback((data: ProfileApiDataSuccess) => {
-    setProfile(data.profile);
+    setLoggedInUserProfile(data.profile);
   }, []);
 
   const logout = useCallback(async () => {
@@ -51,7 +51,7 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
       .then(() => {
         history.push('/login');
         setLoggedInUser(null);
-        setProfile(undefined);
+        setLoggedInUserProfile(undefined);
       })
       .catch((error) => console.error(error));
   }, [history]);
@@ -75,7 +75,9 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
   }, [updateLoginContext, history]);
 
   return (
-    <AuthContext.Provider value={{ loggedInUser, profile, updateLoginContext, updateProfileContext, logout }}>
+    <AuthContext.Provider
+      value={{ loggedInUser, loggedInUserProfile, updateLoginContext, updateProfileContext, logout }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/client/src/context/useAuthContext.tsx
+++ b/client/src/context/useAuthContext.tsx
@@ -4,11 +4,14 @@ import { AuthApiData, AuthApiDataSuccess } from '../interface/AuthApiData';
 import { User } from '../interface/User';
 import loginWithCookies from '../helpers/APICalls/loginWithCookies';
 import logoutAPI from '../helpers/APICalls/logout';
+import { ProfileApiDataSuccess } from '../interface/ProfileApiData';
+import { Profile } from '../interface/Profile';
 
 interface IAuthContext {
   profile: any;
   loggedInUser: User | null | undefined;
   updateLoginContext: (data: AuthApiDataSuccess) => void;
+  updateProfileContext: (data: ProfileApiDataSuccess) => void;
   logout: () => void;
 }
 
@@ -16,13 +19,14 @@ export const AuthContext = createContext<IAuthContext>({
   profile: undefined,
   loggedInUser: undefined,
   updateLoginContext: () => null,
+  updateProfileContext: () => null,
   logout: () => null,
 });
 
 export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
   // default undefined before loading, once loaded provide user or null if logged out
   const [loggedInUser, setLoggedInUser] = useState<User | null | undefined>();
-  const [profile, setProfile] = useState();
+  const [profile, setProfile] = useState<Profile | null | undefined>();
   const history = useHistory();
 
   const updateLoginContext = useCallback(
@@ -36,6 +40,10 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
     },
     [history],
   );
+
+  const updateProfileContext = useCallback((data: ProfileApiDataSuccess) => {
+    setProfile(data.profile);
+  }, []);
 
   const logout = useCallback(async () => {
     // needed to remove token cookie
@@ -67,7 +75,7 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
   }, [updateLoginContext, history]);
 
   return (
-    <AuthContext.Provider value={{ loggedInUser, profile, updateLoginContext, logout }}>
+    <AuthContext.Provider value={{ loggedInUser, profile, updateLoginContext, updateProfileContext, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/client/src/helpers/APICalls/profilePhoto.ts
+++ b/client/src/helpers/APICalls/profilePhoto.ts
@@ -1,0 +1,29 @@
+import { FetchOptions } from '../../interface/FetchOptions';
+import { ProfileApiData } from '../../interface/ProfileApiData';
+
+export const profilePhotoUpload = async (file: File): Promise<ProfileApiData> => {
+  const formData = new FormData();
+  formData.append('image', file);
+  const fetchOptions: FetchOptions = {
+    method: 'POST',
+    body: formData,
+    credentials: 'include',
+  };
+  return await fetch(`/upload/profile-pic`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export const profilePhotoDelete = async (): Promise<ProfileApiData> => {
+  const fetchOptions: FetchOptions = {
+    method: 'DELETE',
+    credentials: 'include',
+  };
+  return await fetch(`/delete/profile-pic`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};

--- a/client/src/interface/AuthApiData.ts
+++ b/client/src/interface/AuthApiData.ts
@@ -1,9 +1,10 @@
 import { User } from './User';
+import { Profile } from './Profile';
 
 export interface AuthApiDataSuccess {
   message: string;
   user: User;
-  profile: any;
+  profile: Profile;
   token: string;
 }
 

--- a/client/src/interface/FetchOptions.ts
+++ b/client/src/interface/FetchOptions.ts
@@ -3,6 +3,6 @@ export interface FetchOptions {
   headers?: {
     'Content-Type': string;
   };
-  body?: string;
+  body?: string | FormData;
   credentials: RequestCredentials;
 }

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -1,0 +1,9 @@
+export interface Profile {
+  address?: string;
+  birthday?: Date;
+  description?: string;
+  gender?: string;
+  name?: string;
+  photo?: string;
+  telephone?: string;
+}

--- a/client/src/interface/ProfileApiData.ts
+++ b/client/src/interface/ProfileApiData.ts
@@ -1,0 +1,10 @@
+import { Profile } from './Profile';
+
+export interface ProfileApiDataSuccess {
+  profile: Profile;
+}
+
+export interface ProfileApiData {
+  error?: { message: string };
+  success?: ProfileApiDataSuccess;
+}

--- a/client/src/pages/Settings/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/pages/Settings/ProfilePhoto/ProfilePhoto.tsx
@@ -5,9 +5,10 @@ import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import AvatarDisplay from '../../../components/AvatarDisplay/AvatarDisplay';
 import SettingHeader from '../../../components/SettingsHeader/SettingsHeader';
 import { User } from '../../../interface/User';
-
 import { makeStyles } from '@mui/styles';
 import { useSnackBar } from '../../../context/useSnackbarContext';
+import { profilePhotoUpload, profilePhotoDelete } from '../../../helpers/APICalls/profilePhoto';
+import { useAuth } from '../../../context/useAuthContext';
 
 const useStyles = makeStyles({
   root: {
@@ -36,10 +37,20 @@ const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ header, currentUser, curren
   const fileInputButton = React.useRef<HTMLInputElement>(null);
   const classes = useStyles();
   const { updateSnackBarMessage } = useSnackBar();
+  const { updateProfileContext } = useAuth();
 
   const fileChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files) {
-      updateSnackBarMessage('Profile Photo uploaded successfuly!!!');
+      profilePhotoUpload(event.target.files[0]).then((data) => {
+        if (data.error) {
+          updateSnackBarMessage(data.error.message);
+        } else if (data.success) {
+          updateProfileContext(data.success);
+          updateSnackBarMessage('Profile Photo is uploaded successfuly!!!');
+        } else {
+          updateSnackBarMessage('An unexpected error occurred. Please try again');
+        }
+      });
     }
   };
   const fileSelectHandler = () => {
@@ -48,7 +59,14 @@ const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ header, currentUser, curren
     }
   };
   const deleteClickHandler = () => {
-    updateSnackBarMessage('Deleted profile photo!!!');
+    profilePhotoDelete().then((data) => {
+      if (data.error) {
+        updateSnackBarMessage(data.error.message);
+      } else if (data.success) {
+        updateProfileContext(data.success);
+        updateSnackBarMessage('Deleted profile photo!!!');
+      }
+    });
   };
   return (
     <Box

--- a/client/src/pages/Settings/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/pages/Settings/ProfilePhoto/ProfilePhoto.tsx
@@ -42,16 +42,21 @@ const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ header, currentUser, curren
 
   const fileChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files) {
-      profilePhotoUpload(event.target.files[0]).then((data) => {
-        if (data.error) {
-          updateSnackBarMessage(data.error.message);
-        } else if (data.success) {
-          updateProfileContext(data.success);
-          updateSnackBarMessage('Profile Photo is uploaded successfuly!!!');
-        } else {
-          updateSnackBarMessage('An unexpected error occurred. Please try again');
-        }
-      });
+      profilePhotoUpload(event.target.files[0])
+        .then((data) => {
+          if (data.error) {
+            updateSnackBarMessage(data.error.message);
+          } else if (data.success) {
+            updateProfileContext(data.success);
+            updateSnackBarMessage('Profile Photo is uploaded successfuly!!!');
+            event.target.value = '';
+          } else {
+            updateSnackBarMessage('An unexpected error occurred. Please try again');
+          }
+        })
+        .catch((err) => {
+          updateSnackBarMessage(err);
+        });
     }
   };
   const fileSelectHandler = () => {
@@ -60,14 +65,18 @@ const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ header, currentUser, curren
     }
   };
   const deleteClickHandler = () => {
-    profilePhotoDelete().then((data) => {
-      if (data.error) {
-        updateSnackBarMessage(data.error.message);
-      } else if (data.success) {
-        updateProfileContext(data.success);
-        updateSnackBarMessage('Deleted profile photo!!!');
-      }
-    });
+    profilePhotoDelete()
+      .then((data) => {
+        if (data.error) {
+          updateSnackBarMessage(data.error.message);
+        } else if (data.success) {
+          updateProfileContext(data.success);
+          updateSnackBarMessage('Deleted profile photo!!!');
+        }
+      })
+      .catch((err) => {
+        updateSnackBarMessage(err);
+      });
   };
   return (
     <Box

--- a/client/src/pages/Settings/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/pages/Settings/ProfilePhoto/ProfilePhoto.tsx
@@ -5,6 +5,7 @@ import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import AvatarDisplay from '../../../components/AvatarDisplay/AvatarDisplay';
 import SettingHeader from '../../../components/SettingsHeader/SettingsHeader';
 import { User } from '../../../interface/User';
+import { Profile } from '../../../interface/Profile';
 import { makeStyles } from '@mui/styles';
 import { useSnackBar } from '../../../context/useSnackbarContext';
 import { profilePhotoUpload, profilePhotoDelete } from '../../../helpers/APICalls/profilePhoto';
@@ -30,7 +31,7 @@ const useStyles = makeStyles({
 interface ProfilePhotoProps {
   header: string;
   currentUser?: User;
-  currentProfile?: any;
+  currentProfile?: Profile;
 }
 
 const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ header, currentUser, currentProfile }) => {
@@ -87,7 +88,7 @@ const ProfilePhoto: React.FC<ProfilePhotoProps> = ({ header, currentUser, curren
               width={170}
               height={170}
               user={currentUser}
-              photoUrl={currentProfile.photo}
+              photoUrl={currentProfile ? currentProfile.photo : ''}
               loggedIn={!!currentUser}
             />
           ) : (

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -40,10 +40,10 @@ const useStyles = makeStyles({
 });
 
 export default function Settings(): JSX.Element {
-  const { loggedInUser, profile } = useAuth();
+  const { loggedInUser, loggedInUserProfile } = useAuth();
   const classes = useStyles();
 
-  if (!profile) {
+  if (loggedInUserProfile === undefined) {
     return <CircularProgress />;
   }
 
@@ -91,7 +91,7 @@ export default function Settings(): JSX.Element {
                     cloneElement(item.component, {
                       ...props,
                       currentUser: loggedInUser,
-                      currentProfile: profile,
+                      currentProfile: loggedInUserProfile,
                     })
                   }
                 />

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -1,6 +1,6 @@
 import { cloneElement } from 'react';
 import { useAuth } from '../../context/useAuthContext';
-import { NavLink, Redirect, Route, Switch, useHistory } from 'react-router-dom';
+import { NavLink, Redirect, Route, Switch } from 'react-router-dom';
 import { Box, CircularProgress, Grid, Link } from '@mui/material';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import { makeStyles } from '@mui/styles';

--- a/server/app.js
+++ b/server/app.js
@@ -14,6 +14,7 @@ const authRouter = require("./routes/auth");
 const userRouter = require("./routes/user");
 const profileRouter = require("./routes/profile");
 const uploadRouter = require("./routes/upload");
+const deleteRouter = require("./routes/delete");
 
 const { json, urlencoded } = express;
 
@@ -52,6 +53,7 @@ app.use("/auth", authRouter);
 app.use("/users", userRouter);
 app.use("/profile", profileRouter);
 app.use("/upload", uploadRouter);
+app.use("/delete", deleteRouter);
 
 if (process.env.NODE_ENV === "production") {
   app.use(express.static(path.join(__dirname, "/client/build")));

--- a/server/controllers/delete.js
+++ b/server/controllers/delete.js
@@ -44,7 +44,7 @@ exports.deleteProfilePic = asyncHandler(async (req, res, next) => {
       });
     });
   } catch (err) {
-    res.status(404);
+    res.status(500);
     throw new Error(err);
   }
 });

--- a/server/controllers/delete.js
+++ b/server/controllers/delete.js
@@ -12,7 +12,6 @@ const deleteFileFromS3bucket = (bucketName, fileName) => {
 // @desc Delete profile photo
 // @access Private
 exports.deleteProfilePic = asyncHandler(async (req, res, next) => {
-  // get the profile
   const profile = await Profile.findOne({ userId: req.user.id });
   if (!profile) {
     res.status(404);
@@ -27,21 +26,20 @@ exports.deleteProfilePic = asyncHandler(async (req, res, next) => {
   try {
     deleteFileFromS3bucket(bucket, filename);
     profile.set({ photo: "" });
-    profile.save().then((profile) => {
-      res.status(200);
-      res.json({
-        success: {
-          profile: {
-            address: profile.address,
-            birthday: profile.birthday,
-            description: profile.description,
-            gender: profile.gender,
-            name: profile.name,
-            photo: profile.photo,
-            telephone: profile.telephone,
-          },
+    const updatedProfile = await profile.save();
+    res.status(200);
+    res.json({
+      success: {
+        profile: {
+          address: updatedProfile.address,
+          birthday: updatedProfile.birthday,
+          description: updatedProfile.description,
+          gender: updatedProfile.gender,
+          name: updatedProfile.name,
+          photo: updatedProfile.photo,
+          telephone: updatedProfile.telephone,
         },
-      });
+      },
     });
   } catch (err) {
     res.status(500);

--- a/server/controllers/delete.js
+++ b/server/controllers/delete.js
@@ -1,0 +1,52 @@
+const asyncHandler = require("express-async-handler");
+const Profile = require("../models/Profile");
+const { s3 } = require("../cloud storage/amazonS3");
+
+const deleteFileFromS3bucket = (bucketName, fileName) => {
+  s3.deleteObject({ Bucket: bucketName, Key: fileName }, (err, res) => {
+    if (err) throw err;
+  });
+};
+
+// @route DELETE /delete/profile-pic
+// @desc Delete profile photo
+// @access Private
+exports.deleteProfilePic = asyncHandler(async (req, res, next) => {
+  // get the profile
+  const profile = await Profile.findOne({ userId: req.user.id });
+  if (!profile) {
+    res.status(404);
+    throw new Error("Profile doesn't exist");
+  }
+  if (profile.photo === "") {
+    res.status(404);
+    throw new Error("Profile photo is not exists!!!");
+  }
+  const filename = profile.photo;
+  const bucket = process.env.AWS_BUCKET_NAME;
+  try {
+    deleteFileFromS3bucket(bucket, filename);
+    profile.set({ photo: "" });
+    profile.save().then((profile) => {
+      res.status(200);
+      res.json({
+        success: {
+          profile: {
+            address: profile.address,
+            birthday: profile.birthday,
+            description: profile.description,
+            gender: profile.gender,
+            name: profile.name,
+            photo: profile.photo,
+            telephone: profile.telephone,
+          },
+        },
+      });
+    });
+  } catch (err) {
+    res.status(404);
+    throw new Error(err);
+  }
+});
+
+exports.deleteFileFromS3bucket = deleteFileFromS3bucket;

--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -55,6 +55,10 @@ exports.uploadProfilePic = asyncHandler(async (req, res, next) => {
           console.error(err);
         }
       }
+      if (!req.file) {
+        res.status(404);
+        throw new Error("Unable to upload photo");
+      }
       profile.set({ photo: req.file.location });
       const updatedProfile = await profile.save();
       res.status(200);

--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -3,12 +3,13 @@ const { s3 } = require("../cloud storage/amazonS3");
 const multer = require("multer");
 const multerS3 = require("multer-s3");
 const Profile = require("../models/Profile");
+const { deleteFileFromS3bucket } = require("./delete");
 
 const imageFilter = (req, file, cb) => {
   if (file.mimetype.startsWith("image")) {
     cb(null, true);
   } else {
-    cb(new Error("Not an image! Please upload images only."));
+    cb("Not an image! Please upload images only.", false);
   }
 };
 
@@ -28,6 +29,9 @@ const upload = (bucketName, filename) =>
     fileFilter: imageFilter,
   });
 
+// @route POST /upload/profile-pic
+// @desc upload profile photo
+// @access Private
 exports.uploadProfilePic = asyncHandler(async (req, res, next) => {
   const profile = await Profile.findOne({ userId: req.user.id });
   if (!profile) {
@@ -35,23 +39,43 @@ exports.uploadProfilePic = asyncHandler(async (req, res, next) => {
     throw new Error("Profile doesn't exist");
   }
 
-  const filename = `${req.user.id}-profile-pic.jpg`;
+  const filename = `profile-pics/${Date.now()}`;
   const bucket = process.env.AWS_BUCKET_NAME;
 
   try {
     const uploadSingle = upload(bucket, filename).single("image");
 
     uploadSingle(req, res, (err) => {
-      if (err) return res.status(400).json(err);
+      if (err) return res.status(400).json({ error: { message: err } });
 
+      // now can saftly delete old photo
+      if (profile.photo !== "") {
+        try {
+          deleteFileFromS3bucket(bucket, profile.photo);
+        } catch (err) {
+          console.error(err);
+        }
+      }
       profile.set({ photo: req.file.location });
       profile.save().then((profile) => {
         res.status(200);
-        res.json({ profile });
+        res.json({
+          success: {
+            profile: {
+              address: profile.address,
+              birthday: profile.birthday,
+              description: profile.description,
+              gender: profile.gender,
+              name: profile.name,
+              photo: profile.photo,
+              telephone: profile.telephone,
+            },
+          },
+        });
       });
     });
   } catch (err) {
     res.status(500);
-    throw new Error({ error: err });
+    throw new Error(err);
   }
 });

--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -45,10 +45,9 @@ exports.uploadProfilePic = asyncHandler(async (req, res, next) => {
   try {
     const uploadSingle = upload(bucket, filename).single("image");
 
-    uploadSingle(req, res, (err) => {
+    uploadSingle(req, res, async (err) => {
       if (err) return res.status(400).json({ error: { message: err } });
 
-      // now can saftly delete old photo
       if (profile.photo !== "") {
         try {
           deleteFileFromS3bucket(bucket, profile.photo);
@@ -57,21 +56,20 @@ exports.uploadProfilePic = asyncHandler(async (req, res, next) => {
         }
       }
       profile.set({ photo: req.file.location });
-      profile.save().then((profile) => {
-        res.status(200);
-        res.json({
-          success: {
-            profile: {
-              address: profile.address,
-              birthday: profile.birthday,
-              description: profile.description,
-              gender: profile.gender,
-              name: profile.name,
-              photo: profile.photo,
-              telephone: profile.telephone,
-            },
+      const updatedProfile = await profile.save();
+      res.status(200);
+      res.json({
+        success: {
+          profile: {
+            address: updatedProfile.address,
+            birthday: updatedProfile.birthday,
+            description: updatedProfile.description,
+            gender: updatedProfile.gender,
+            name: updatedProfile.name,
+            photo: updatedProfile.photo,
+            telephone: updatedProfile.telephone,
           },
-        });
+        },
       });
     });
   } catch (err) {

--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -12,5 +12,5 @@ exports.errorHandler = (err, req, res, next) => {
   const statusCode = res.statusCode === 200 ? 500 : res.statusCode;
 
   res.status(statusCode);
-  res.json({ error: err.message });
+  res.json({ error: { message: err.message } });
 };

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -18,7 +18,6 @@ const profileSchema = new mongoose.Schema({
     type: String,
     default: "none",
   },
-  },
   telephone: {
     type: String,
     default: "",

--- a/server/package.json
+++ b/server/package.json
@@ -6,10 +6,12 @@
     "test": "test"
   },
   "scripts": {
+    "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nodemon ./bin/www"
   },
   "dependencies": {
+    "aws-sdk": "^2.1058.0",
     "bcryptjs": "^2.4.3",
     "colors": "^1.4.0",
     "cookie-parser": "^1.4.6",
@@ -21,6 +23,8 @@
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.0.13",
     "morgan": "^1.10.0",
+    "multer": "^1.4.4",
+    "multer-s3": "^2.10.0",
     "nodemon": "^2.0.15",
     "socket.io": "^4.3.2"
   },

--- a/server/routes/delete.js
+++ b/server/routes/delete.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const protect = require("../middleware/auth");
+const { deleteProfilePic } = require("../controllers/delete");
+
+router.route("/profile-pic").delete(protect, deleteProfilePic);
+
+module.exports = router;


### PR DESCRIPTION
### What this PR does (required):
#### Integrates server and client to upload and delete images
- creates interface for profile model
- adds API calls to upload and delete profile photo
- creates context to update profile
- adds handler to upload and delete buttons to call APIs to upload and delete profile photo
- creates delete profile photo controller
- fixes upload profile photo controller to handle "un-supported file" error and return updated profile on success
- add routes to delete profile photo

### Any information needed to test this feature (required):
- Login/Signup and go profile photo setting page by navigating to `/profile/settings/profile-photo `
- Click on 'upload file from your device' button and choose any image
- This will upload the selected image to the AWS s3 bucket and also display the photo on the UI
- Now click on "delete photo" button.
- This will delete the profile photo from AWS s3 bucket and display the first letter of username on the UI
- Now again 'click' on 'upload file from your device' and this time select a non-image file
- This will show a snack bar on the bottom with the message "Not an image, please select a valid image!!!"

### Any issues with the current functionality (optional):
- There is no issue discovered right now
