### PR TITLE
Integration of Messaging feature

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,7 +13,7 @@ import { SnackBarProvider } from './context/useSnackbarContext';
 import { Navbar } from './components/Navbar/Navbar';
 import Settings from './pages/Settings/Settings';
 import NotFound from './pages/NotFound/NotFound';
-import MessagesDashboard from './pages/Messages/Messages';
+import MessagesDashboard from './pages/Messages/MessagesDashboard';
 
 function App(): JSX.Element {
   return (

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import { SnackBarProvider } from './context/useSnackbarContext';
 import { Navbar } from './components/Navbar/Navbar';
 import Settings from './pages/Settings/Settings';
 import NotFound from './pages/NotFound/NotFound';
+import MessagesDashboard from './pages/Messages/Messages';
 
 function App(): JSX.Element {
   return (
@@ -28,6 +29,7 @@ function App(): JSX.Element {
                 <Route exact path="/signup" component={Signup} />
                 <Route exact path="/dashboard" component={Dashboard} />
                 <Route path="/profile/settings" component={Settings} />
+                <Route path="/messages" component={MessagesDashboard} />
                 <Route path="*">
                   <NotFound />
                 </Route>

--- a/client/src/helpers/APICalls/Messages/createConversation.ts
+++ b/client/src/helpers/APICalls/Messages/createConversation.ts
@@ -7,7 +7,7 @@ const createConversation = async (receiver: string, description: string) => {
     body: JSON.stringify({ receiver, description }),
     credentials: 'include',
   };
-  return await fetch(`/conversations/create-conversation/`, fetchOptions)
+  return await fetch(`/conversations/`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({
       error: { message: 'Unable to connect to server. Please try again' },

--- a/client/src/helpers/APICalls/Messages/createConversation.ts
+++ b/client/src/helpers/APICalls/Messages/createConversation.ts
@@ -1,0 +1,17 @@
+import { FetchOptions } from '../../../interface/FetchOptions';
+
+const createConversation = async (receiver: string, description: string) => {
+  const fetchOptions: FetchOptions = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ receiver, description }),
+    credentials: 'include',
+  };
+  return await fetch(`/conversations/create-conversation/`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export default createConversation;

--- a/client/src/helpers/APICalls/Messages/getAllMessages.ts
+++ b/client/src/helpers/APICalls/Messages/getAllMessages.ts
@@ -1,0 +1,15 @@
+import { FetchOptions } from '../../../interface/FetchOptions';
+
+const getAllMessages = async (conversationId: string) => {
+  const fetchOptions: FetchOptions = {
+    method: 'GET',
+    credentials: 'include',
+  };
+  return await fetch(`/conversations/${conversationId}/messages`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export default getAllMessages;

--- a/client/src/helpers/APICalls/Messages/getConversations.tsx
+++ b/client/src/helpers/APICalls/Messages/getConversations.tsx
@@ -1,0 +1,15 @@
+import { FetchOptions } from '../../../interface/FetchOptions';
+
+const getConversations = async () => {
+  const fetchOptions: FetchOptions = {
+    method: 'GET',
+    credentials: 'include',
+  };
+  return await fetch(`/conversations/all`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export default getConversations;

--- a/client/src/helpers/APICalls/Messages/sendMessage.ts
+++ b/client/src/helpers/APICalls/Messages/sendMessage.ts
@@ -1,10 +1,10 @@
 import { FetchOptions } from '../../../interface/FetchOptions';
 
-const sendMessage = async (receiver: string, description: string, conversationId: string) => {
+const sendMessage = async (description: string, conversationId: string) => {
   const fetchOptions: FetchOptions = {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ receiver, description, conversationId }),
+    body: JSON.stringify({ description, conversationId }),
     credentials: 'include',
   };
   return await fetch(`/conversations/message`, fetchOptions)

--- a/client/src/helpers/APICalls/Messages/sendMessage.ts
+++ b/client/src/helpers/APICalls/Messages/sendMessage.ts
@@ -1,0 +1,17 @@
+import { FetchOptions } from '../../../interface/FetchOptions';
+
+const sendMessage = async (receiver: string, description: string, conversationId: string) => {
+  const fetchOptions: FetchOptions = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ receiver, description, conversationId }),
+    credentials: 'include',
+  };
+  return await fetch(`/conversations/message`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export default sendMessage;

--- a/client/src/interface/Conversation.ts
+++ b/client/src/interface/Conversation.ts
@@ -1,0 +1,21 @@
+export interface Message {
+  sender: string;
+  receiver: string;
+  description: string;
+  _id: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface userId {
+  _id: string;
+}
+
+export default interface Conversation {
+  user: string;
+  messages: [Message];
+  participants: [userId];
+  _id: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/client/src/interface/Conversation.ts
+++ b/client/src/interface/Conversation.ts
@@ -1,16 +1,16 @@
+interface User {
+  email: string;
+  name: string;
+  _id: string;
+}
+
 export interface Message {
-  sender: string;
+  sender: User;
   receiver: string;
   description: string;
   _id: string;
   createdAt: string;
   updatedAt: string;
-}
-
-interface User {
-  email: string;
-  name: string;
-  _id: string;
 }
 
 export default interface Conversation {

--- a/client/src/interface/Conversation.ts
+++ b/client/src/interface/Conversation.ts
@@ -10,6 +10,7 @@ export interface Message {
 interface User {
   email: string;
   name: string;
+  _id: string;
 }
 
 export default interface Conversation {

--- a/client/src/interface/Conversation.ts
+++ b/client/src/interface/Conversation.ts
@@ -4,9 +4,8 @@ interface User {
   _id: string;
 }
 
-export interface Message {
+export interface MessageInterface {
   sender: User;
-  receiver: string;
   description: string;
   _id: string;
   createdAt: string;
@@ -15,7 +14,7 @@ export interface Message {
 
 export default interface Conversation {
   user: string;
-  messages: [Message];
+  messages: [MessageInterface];
   participants: [User, User];
   _id: string;
   createdAt: string;

--- a/client/src/interface/Conversation.ts
+++ b/client/src/interface/Conversation.ts
@@ -7,14 +7,15 @@ export interface Message {
   updatedAt: string;
 }
 
-interface userId {
-  _id: string;
+interface User {
+  email: string;
+  name: string;
 }
 
 export default interface Conversation {
   user: string;
   messages: [Message];
-  participants: [userId];
+  participants: [User, User];
   _id: string;
   createdAt: string;
   updatedAt: string;

--- a/client/src/pages/Messages/CreateConversation.tsx
+++ b/client/src/pages/Messages/CreateConversation.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { Box, Button, TextField, Stack } from '@mui/material';
+import createConversation from '../../helpers/APICalls/Messages/createConversation';
+import { useSnackBar } from '../../context/useSnackbarContext';
+import SendIcon from '@mui/icons-material/Send';
+import CircularProgress from '@mui/material/CircularProgress';
+
+export default function CreateConversation() {
+  const [isSubmitting, setSubmitting] = useState(false);
+  const { updateSnackBarMessage } = useSnackBar();
+  const [message, setMessage] = useState<string>('');
+  const [receiver, setReceiver] = useState<string>('');
+
+  const handleSubmit = (receiver: string, description: string) => {
+    setSubmitting(true);
+    createConversation(receiver, description).then((data) => {
+      if (data.error) {
+        setSubmitting(false);
+        updateSnackBarMessage(data.error.message);
+      } else if (data.success) {
+        updateSnackBarMessage('Message sent!');
+        setSubmitting(false);
+      } else {
+        // should not get here from backend but this catch is for an unknown issue
+        console.error({ data });
+        setSubmitting(false);
+        updateSnackBarMessage('An unexpected error occurred. Please try again');
+      }
+    });
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.id === 'message') {
+      setMessage(event.target.value);
+    } else {
+      setReceiver(event.target.value);
+    }
+  };
+
+  return (
+    <Box
+      component="form"
+      sx={{
+        width: 300,
+      }}
+      onSubmit={() => handleSubmit(receiver, message)}
+    >
+      {' '}
+      {isSubmitting ? (
+        <CircularProgress />
+      ) : (
+        <Stack spacing={3}>
+          <TextField sx={{ minWidth: '200px' }} id="message" label="message" value={message} onChange={handleChange} />
+
+          <TextField sx={{ minWidth: '50px' }} id="receiver" label="user" value={receiver} onChange={handleChange} />
+
+          <Button
+            onClick={() => handleSubmit(receiver, message)}
+            color="primary"
+            variant="contained"
+            endIcon={<SendIcon />}
+            sx={{
+              width: 100,
+              margin: 'auto',
+            }}
+          >
+            Send
+          </Button>
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/client/src/pages/Messages/Message/Message.tsx
+++ b/client/src/pages/Messages/Message/Message.tsx
@@ -1,0 +1,42 @@
+import React, { ReactElement } from 'react';
+import { MessageInterface } from '../../../interface/Conversation';
+import moment from 'moment';
+import { Grid, ListItemText, ListItem, Avatar, Typography, ListItemAvatar, List } from '@mui/material';
+import { useStyles } from './useStyles';
+import { useAuth } from '../../../context/useAuthContext';
+
+interface Props {
+  message: MessageInterface;
+}
+
+export default function Message({ message }: Props): ReactElement {
+  const { loggedInUser } = useAuth();
+
+  const sender = message.sender.name === loggedInUser?.name ? true : false;
+
+  const classes = useStyles(sender);
+
+  return (
+    <Grid sx={{ flexDirection: 'row' }} flexDirection={'row'} container>
+      <List sx={{ display: 'flex', flexDirection: 'row' }}>
+        <Grid className={classes.root} item xs={12}>
+          <ListItem>
+            <ListItemAvatar>
+              <Avatar alt="profile picture" src="/static/images/avatar/1.jpg" />
+            </ListItemAvatar>
+            <ListItemText
+              primary={message.description}
+              secondary={
+                <React.Fragment>
+                  <Typography component="span" variant="body2" color="text.primary">
+                    {moment(message.updatedAt).calendar()}
+                  </Typography>
+                </React.Fragment>
+              }
+            />
+          </ListItem>
+        </Grid>
+      </List>
+    </Grid>
+  );
+}

--- a/client/src/pages/Messages/Message/Message.tsx
+++ b/client/src/pages/Messages/Message/Message.tsx
@@ -17,8 +17,8 @@ export default function Message({ message }: Props): ReactElement {
   const classes = useStyles(sender);
 
   return (
-    <Grid sx={{ flexDirection: 'row' }} flexDirection={'row'} container>
-      <List sx={{ display: 'flex', flexDirection: 'row' }}>
+    <Grid container>
+      <List>
         <Grid className={classes.root} item xs={12}>
           <ListItem>
             <ListItemAvatar>

--- a/client/src/pages/Messages/Message/useStyles.ts
+++ b/client/src/pages/Messages/Message/useStyles.ts
@@ -1,0 +1,17 @@
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { useAuth } from '../../../context/useAuthContext';
+import { MessageInterface } from '../../../interface/Conversation';
+import { User } from '../../../interface/User';
+
+export const useStyles = makeStyles((sender: boolean) => ({
+  root: {
+    '& .MuiListItem-root': {
+      justifyContent: (sender) => (sender ? 'flex-start' : 'flex-end'),
+      backgroundColor: (sender) => (sender ? 'white' : '#D3D3D3'),
+      fontWeight: 700,
+      textDecoration: 'none',
+      borderRadius: '25px',
+    },
+  },
+}));

--- a/client/src/pages/Messages/Messages.tsx
+++ b/client/src/pages/Messages/Messages.tsx
@@ -1,8 +1,11 @@
+import { useEffect, useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import PageContainer from '../../components/PageContainer/PageContainer';
-
-import dogNotFound from '../../images/notFound/dog_not_found.png';
 import { makeStyles } from '@mui/styles';
+import { useAuth } from '../../context/useAuthContext';
+import ConversationInterface from '../../interface/Conversation';
+import getConversations from '../../helpers/APICalls/Messages/getConversations';
+import { useSnackBar } from '../../context/useSnackbarContext';
 
 const useStyles = makeStyles({
   image: {
@@ -10,25 +13,41 @@ const useStyles = makeStyles({
   },
 });
 
+type Conversations = ConversationInterface[];
+
 export default function MessagesDashboard(): JSX.Element {
   const classes = useStyles();
 
+  const [conversations, setConversations] = useState<Conversations>([]);
+  const [isSubmitting, setSubmitting] = useState(false);
+  const { updateSnackBarMessage } = useSnackBar();
+
+  const { loggedInUser } = useAuth();
+
+  useEffect(() => {
+    setSubmitting(true);
+
+    getConversations().then((data) => {
+      if (data.error) {
+        updateSnackBarMessage(data.error.message);
+      } else if (data.success) {
+        const conversations = data.success.conversations;
+        console.log(conversations);
+
+        setConversations(conversations);
+
+        setSubmitting(false);
+      } else {
+        console.error({ data });
+        setSubmitting(false);
+        updateSnackBarMessage('An unexpected error occurred. Please try again');
+      }
+    });
+  }, []);
+
   return (
     <PageContainer>
-      <Box sx={{ width: '50%', margin: '0 auto', textAlign: 'center' }}>
-        <Typography
-          sx={{
-            color: 'primary.main',
-            textAlign: 'center',
-          }}
-          variant="h2"
-        >
-          Sorry we couldn&apos;t get that page.
-        </Typography>
-        <Box sx={{ width: 600, margin: '20px auto' }}>
-          <img className={classes.image} src={dogNotFound} />
-        </Box>
-      </Box>
+      <Box sx={{ width: '50%', margin: '0 auto', textAlign: 'center' }}>{isSubmitting ? 'loading' : 'done'}</Box>
     </PageContainer>
   );
 }

--- a/client/src/pages/Messages/Messages.tsx
+++ b/client/src/pages/Messages/Messages.tsx
@@ -64,9 +64,9 @@ export default function MessagesDashboard(): JSX.Element {
     }
   }, [chatbox]);
 
-  const handleSubmit = (receiver: string, description: string, conversationId: string) => {
+  const handleSubmit = (description: string, conversationId: string) => {
     setSubmitting(true);
-    sendMessage(receiver, description, conversationId).then((data) => {
+    sendMessage(description, conversationId).then((data) => {
       if (data.error) {
         setSubmitting(false);
         updateSnackBarMessage(data.error.message);
@@ -195,9 +195,7 @@ export default function MessagesDashboard(): JSX.Element {
                 </Grid>
                 <Grid xs={1}>
                   <Button
-                    onClick={() =>
-                      handleSubmit(conversations[chatbox].participants[0]._id, message, conversations[chatbox]._id)
-                    }
+                    onClick={() => handleSubmit(message, conversations[chatbox]._id)}
                     color="primary"
                     variant="contained"
                   >

--- a/client/src/pages/Messages/Messages.tsx
+++ b/client/src/pages/Messages/Messages.tsx
@@ -1,0 +1,34 @@
+import { Box, Typography } from '@mui/material';
+import PageContainer from '../../components/PageContainer/PageContainer';
+
+import dogNotFound from '../../images/notFound/dog_not_found.png';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles({
+  image: {
+    width: '100%',
+  },
+});
+
+export default function MessagesDashboard(): JSX.Element {
+  const classes = useStyles();
+
+  return (
+    <PageContainer>
+      <Box sx={{ width: '50%', margin: '0 auto', textAlign: 'center' }}>
+        <Typography
+          sx={{
+            color: 'primary.main',
+            textAlign: 'center',
+          }}
+          variant="h2"
+        >
+          Sorry we couldn&apos;t get that page.
+        </Typography>
+        <Box sx={{ width: 600, margin: '20px auto' }}>
+          <img className={classes.image} src={dogNotFound} />
+        </Box>
+      </Box>
+    </PageContainer>
+  );
+}

--- a/client/src/pages/Messages/Messages.tsx
+++ b/client/src/pages/Messages/Messages.tsx
@@ -1,27 +1,53 @@
 import { useEffect, useState } from 'react';
-import { Box, Typography } from '@mui/material';
+import {
+  Box,
+  Typography,
+  Grid,
+  List,
+  ListItem,
+  ListItemIcon,
+  Avatar,
+  ListItemText,
+  Divider,
+  Paper,
+  Fab,
+  TextField,
+} from '@mui/material';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import { makeStyles } from '@mui/styles';
 import { useAuth } from '../../context/useAuthContext';
 import ConversationInterface from '../../interface/Conversation';
 import getConversations from '../../helpers/APICalls/Messages/getConversations';
 import { useSnackBar } from '../../context/useSnackbarContext';
+import moment from 'moment';
 
 const useStyles = makeStyles({
-  image: {
+  table: {
+    minWidth: 650,
+  },
+  inboxSection: {
     width: '100%',
+    height: '80vh',
+  },
+  messageSection: {
+    height: '70vh',
+    overflowY: 'auto',
+  },
+  borderRight500: {
+    borderRight: '1px solid #e0e0e0',
+  },
+  headBG: {
+    backgroundColor: '#e0e0e0',
   },
 });
-
 type Conversations = ConversationInterface[];
 
 export default function MessagesDashboard(): JSX.Element {
   const classes = useStyles();
-
   const [conversations, setConversations] = useState<Conversations>([]);
   const [isSubmitting, setSubmitting] = useState(false);
   const { updateSnackBarMessage } = useSnackBar();
-
+  const [chatbox, setChatBox] = useState<number>(0);
   const { loggedInUser } = useAuth();
 
   useEffect(() => {
@@ -32,7 +58,8 @@ export default function MessagesDashboard(): JSX.Element {
         updateSnackBarMessage(data.error.message);
       } else if (data.success) {
         const conversations = data.success.conversations;
-        console.log(conversations);
+
+        setChatBox(conversations.length);
 
         setConversations(conversations);
 
@@ -43,11 +70,81 @@ export default function MessagesDashboard(): JSX.Element {
         updateSnackBarMessage('An unexpected error occurred. Please try again');
       }
     });
-  }, []);
+  }, [updateSnackBarMessage]);
 
   return (
     <PageContainer>
-      <Box sx={{ width: '50%', margin: '0 auto', textAlign: 'center' }}>{isSubmitting ? 'loading' : 'done'}</Box>
+      <Box>
+        <Grid container>
+          <Grid item xs={12}>
+            <Typography variant="h6" className="header-message">
+              Inbox
+            </Typography>
+          </Grid>
+        </Grid>
+        <Grid container component={Paper} className={classes.inboxSection}>
+          <Grid item xs={3} className={classes.borderRight500}>
+            <Divider />
+            <List>
+              {conversations.map((conversation, index) => (
+                <ListItem button onClick={() => setChatBox(index)} key={conversation._id}>
+                  <ListItemIcon>
+                    <Avatar
+                      alt={
+                        conversation.participants[0].name === loggedInUser?.name
+                          ? `${conversation.participants[0].name}s profile picture`
+                          : `${conversation.participants[1].name}s profile picture`
+                      }
+                      src="https://material-ui.com/static/images/avatar/1.jpg"
+                    />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={
+                      conversation.participants[0].name === loggedInUser?.name
+                        ? `${conversation.participants[0].name}`
+                        : `${conversation.participants[1].name}`
+                    }
+                  >
+                    {conversation.participants[0].name === loggedInUser?.name
+                      ? `${conversation.participants[0].name}`
+                      : `${conversation.participants[1].name}`}
+                  </ListItemText>
+                  <ListItemText secondary={`${conversation.updatedAt}`}></ListItemText>
+                </ListItem>
+              ))}
+            </List>
+          </Grid>
+          <Grid item xs={9}>
+            <List className={classes.messageSection}>
+              {!isSubmitting &&
+                conversations[chatbox] &&
+                conversations[chatbox].messages.map((message, index) => (
+                  <ListItem key={message._id}>
+                    <Grid container>
+                      <Grid alignItems="right" item xs={12}>
+                        <ListItemText primary={message.description}></ListItemText>
+                      </Grid>
+                      <Grid alignItems="right" item xs={12}>
+                        <ListItemText secondary={moment(message.updatedAt).calendar()}></ListItemText>
+                      </Grid>
+                    </Grid>
+                  </ListItem>
+                ))}
+            </List>
+            <Divider />
+            <Grid container style={{ padding: '20px' }}>
+              <Grid item xs={11}>
+                <TextField id="send-message" label="Reply" fullWidth />
+              </Grid>
+              <Grid xs={1}>
+                <Fab color="primary" aria-label="add">
+                  Send
+                </Fab>
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Box>
     </PageContainer>
   );
 }

--- a/client/src/pages/Messages/MessagesDashboard.tsx
+++ b/client/src/pages/Messages/MessagesDashboard.tsx
@@ -15,7 +15,6 @@ import {
   Modal,
 } from '@mui/material';
 import PageContainer from '../../components/PageContainer/PageContainer';
-import { makeStyles } from '@mui/styles';
 import { useAuth } from '../../context/useAuthContext';
 import ConversationInterface from '../../interface/Conversation';
 import getConversations from '../../helpers/APICalls/Messages/getConversations';
@@ -26,32 +25,13 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Message from './Message/Message';
 import SendIcon from '@mui/icons-material/Send';
 import CreateConversation from './CreateConversation';
-
-const useStyles = makeStyles({
-  table: {
-    minWidth: 650,
-    minHeight: 900,
-  },
-  inboxSection: {
-    width: '100%',
-    height: '90vh',
-  },
-  messageSection: {
-    height: '65vh',
-    overflowY: 'auto',
-  },
-  borderRight500: {
-    borderRight: '1px solid #e0e0e0',
-  },
-  headBG: {
-    backgroundColor: '#e0e0e0',
-  },
-});
+import useStyles from './useStyles';
 
 type Conversations = ConversationInterface[];
 
 export default function MessagesDashboard(): JSX.Element {
   const classes = useStyles();
+
   const [conversations, setConversations] = useState<Conversations>([]);
   const [isSubmitting, setSubmitting] = useState(false);
   const { updateSnackBarMessage } = useSnackBar();
@@ -252,17 +232,11 @@ export default function MessagesDashboard(): JSX.Element {
         >
           <Box
             sx={{
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-              width: 400,
-              height: 400,
               bgcolor: 'background.paper',
-              border: '2px solid #000',
-              boxShadow: 24,
+              boxShadow: '24',
               p: 4,
             }}
+            className={classes.modal}
           >
             <Typography id="modal-modal-title" variant="h6" component="h2">
               Start a new conversation

--- a/client/src/pages/Messages/useStyles.ts
+++ b/client/src/pages/Messages/useStyles.ts
@@ -1,0 +1,33 @@
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles({
+  table: {
+    minWidth: 650,
+    minHeight: 900,
+  },
+  inboxSection: {
+    width: '100%',
+    height: '90vh',
+  },
+  messageSection: {
+    height: '65vh',
+    overflowY: 'auto',
+  },
+  borderRight500: {
+    borderRight: '1px solid #e0e0e0',
+  },
+  headBG: {
+    backgroundColor: '#e0e0e0',
+  },
+  modal: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: 400,
+    height: 400,
+    border: '2px solid #000',
+  },
+});
+
+export default useStyles;

--- a/server/controllers/conversation.js
+++ b/server/controllers/conversation.js
@@ -103,7 +103,7 @@ exports.getAllConversations = asyncHandler(async (req, res, next) => {
   }).populate({
     path: 'messages',
     sort: { updatedAt: 'desc' },
-  });
+  }).populate('participants')
 
   res.status(200).json({
     success: {

--- a/server/controllers/conversation.js
+++ b/server/controllers/conversation.js
@@ -103,7 +103,13 @@ exports.getAllConversations = asyncHandler(async (req, res, next) => {
   }).populate({
     path: 'messages',
     sort: { updatedAt: 'desc' },
+       populate: {
+       path: 'sender',
+       model: 'User'
+     } 
   }).populate('participants')
+
+
 
   res.status(200).json({
     success: {

--- a/server/controllers/conversation.js
+++ b/server/controllers/conversation.js
@@ -126,6 +126,10 @@ exports.getAllConversations = asyncHandler(async (req, res, next) => {
     .populate({
       path: "messages",
       sort: { updatedAt: "desc" },
+      populate: {
+        path: "sender",
+        model: "User",
+      },
     })
     .populate("participants");
 

--- a/server/controllers/conversation.js
+++ b/server/controllers/conversation.js
@@ -82,7 +82,7 @@ exports.getAllMessages = asyncHandler(async (req, res, next) => {
 // @access Private
 
 exports.sendMessage = asyncHandler(async (req, res, next) => {
-  const { conversationId, description  } = req.body;
+  const { conversationId, description } = req.body;
 
   if (!description || !receiver || !conversationId) {
     res.status(400);
@@ -122,10 +122,12 @@ exports.sendMessage = asyncHandler(async (req, res, next) => {
 exports.getAllConversations = asyncHandler(async (req, res, next) => {
   const conversations = await Conversation.find({
     participants: { $in: req.user.id },
-  }).populate({
-    path: "messages",
-    sort: { updatedAt: "desc" },
-  });
+  })
+    .populate({
+      path: "messages",
+      sort: { updatedAt: "desc" },
+    })
+    .populate("participants");
 
   res.status(200).json({
     success: {

--- a/server/controllers/conversation.js
+++ b/server/controllers/conversation.js
@@ -84,7 +84,7 @@ exports.getAllMessages = asyncHandler(async (req, res, next) => {
 exports.sendMessage = asyncHandler(async (req, res, next) => {
   const { conversationId, description } = req.body;
 
-  if (!description || !receiver || !conversationId) {
+  if (!description || !conversationId) {
     res.status(400);
     throw new Error("Bad request!");
   }

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -35,4 +35,4 @@ userSchema.pre("save", async function (next) {
   this.password = await bcrypt.hash(this.password, salt);
 });
 
-module.exports = User = mongoose.model("user", userSchema);
+module.exports = User = mongoose.model("User", userSchema);


### PR DESCRIPTION
### What this PR does (required):
Integrates the frontend messaging component with the backend and allows users to send, receive, and start conversations with other users. 

### Screenshots / Videos (front-end only):
![demo screenshot](https://i.imgur.com/SaHteiq.png)
![demo screenshot](https://i.imgur.com/J9vO0jD.png)

### Any information needed to test this feature (required):
Login with any user
Go to the messages tab
Currently you need to have the userId of another user to create a conversation but I assume we will handle starting conversations a different way with another ticket. It was not clear to me according to the mocks. 
click the start new conversation modal button and send a message to any user. 

The state will rerender when you send a new message and you will be able to immediately see it. 

Once you start a new conversation it will remain in your inbox and you will be able to send messages in the chat window. 

### Any issues with the current functionality (optional):
Was still having trouble with MUI, could not change the flex direction of the messages to display based on who sent the message. 
I could not get the scroll to start at bottom when you post a new message, but when you switch between tabs it saves the scroll position ref. 
The state will rerender when you send a new message and you will be able to immediately see it. 

