### PR TITLE
Profile details page integration

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,7 +33,7 @@ function App(): JSX.Element {
                 <ProtectedRoute exact path="/dashboard" component={Dashboard} />
                 <ProtectedRoute path="/profile/settings" component={Settings} />
                 <ProtectedRoute path="/bookings" component={Bookings} />
-                <ProtectedRoute path="/profile/exampleid" component={ProfileDetails} />
+                <ProtectedRoute path="/profile/:profileId" component={ProfileDetails} />
                 <Route path="*">
                   <NotFound />
                 </Route>

--- a/client/src/components/BookingCard/BookingCard.tsx
+++ b/client/src/components/BookingCard/BookingCard.tsx
@@ -81,7 +81,7 @@ export default function BookingCard({ booking, isNextBooking, isPastBooking }: P
       {topLine()}
       <Box sx={{ padding: '0', display: 'flex', alignItems: 'center', marginBottom: 0 }}>
         <AvatarDisplay loggedIn={false} user={booking.user} />
-        <Typography sx={{ textTransform: 'none', fontWeight: 'bold' }}>{booking.user.name}</Typography>
+        <Typography sx={{ textTransform: 'none', fontWeight: 'bold' }}>&nbsp;{booking.user.name}</Typography>
         <Typography
           sx={{
             alignSelf: 'flex-start',

--- a/client/src/components/BookingCard/BookingCard.tsx
+++ b/client/src/components/BookingCard/BookingCard.tsx
@@ -39,6 +39,10 @@ export default function BookingCard({ booking, isNextBooking, isPastBooking }: P
         updateSnackBarMessage(data.error);
       } else if (data.success) {
         updateSnackBarMessage('Status successfully changed');
+      } else {
+        // should not get here from backend but this catch is for an unknown issue
+        console.error({ data });
+        updateSnackBarMessage('An unexpected error occurred. Please try again');
       }
     });
   };

--- a/client/src/components/BookingCard/BookingCard.tsx
+++ b/client/src/components/BookingCard/BookingCard.tsx
@@ -36,7 +36,7 @@ export default function BookingCard({ booking, isNextBooking, isPastBooking }: P
     changeRequestStatus(booking.id, newStatus).then((data) => {
       if (data.error) {
         console.error({ error: data.error.message });
-        updateSnackBarMessage(data.error);
+        updateSnackBarMessage(data.error.message);
       } else if (data.success) {
         updateSnackBarMessage('Status successfully changed');
       } else {

--- a/client/src/helpers/APICalls/createRequest.ts
+++ b/client/src/helpers/APICalls/createRequest.ts
@@ -1,16 +1,17 @@
 import { FetchOptions } from './../../interface/FetchOptions';
 
-const getRequests = async () => {
+const createRequest = async (sitter: string, startDate: Date, endDate: Date) => {
   const fetchOptions: FetchOptions = {
-    method: 'GET',
+    method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
+    body: JSON.stringify({ sitter, startDate, endDate }),
   };
-  return await fetch(`/requests`, fetchOptions)
+  return await fetch(`/requests/`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({
       error: { message: 'Unable to connect to server. Please try again' },
     }));
 };
 
-export default getRequests;
+export default createRequest;

--- a/client/src/helpers/APICalls/getProfile.ts
+++ b/client/src/helpers/APICalls/getProfile.ts
@@ -1,0 +1,17 @@
+import { FetchOptions } from './../../interface/FetchOptions';
+
+const getProfile = async (profileId: string) => {
+  const fetchOptions: FetchOptions = {
+    method: 'GET',
+    credentials: 'include',
+  };
+  return await fetch(`/profiles/load/${profileId}`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: {
+        message: 'Unable to connect to server. Please try again',
+      },
+    }));
+};
+
+export default getProfile;

--- a/client/src/helpers/APICalls/getProfile.ts
+++ b/client/src/helpers/APICalls/getProfile.ts
@@ -5,7 +5,7 @@ const getProfile = async (profileId: string) => {
     method: 'GET',
     credentials: 'include',
   };
-  return await fetch(`/profiles/load/${profileId}`, fetchOptions)
+  return await fetch(`/profile/load/${profileId}`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({
       error: {

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -1,5 +1,7 @@
-export interface Profile {
+export default interface Profile {
   name: string;
   description: string;
   aboutMe: string;
+  payRate: string;
+  location: string;
 }

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -1,0 +1,5 @@
+export interface Profile {
+  name: string;
+  description: string;
+  aboutMe: string;
+}

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -4,4 +4,5 @@ export default interface Profile {
   aboutMe: string;
   payRate: string;
   location: string;
+  photo: string;
 }

--- a/client/src/pages/Bookings/Bookings.tsx
+++ b/client/src/pages/Bookings/Bookings.tsx
@@ -23,6 +23,7 @@ export default function Bookings(): JSX.Element {
     if (!mounted) {
       setMounted(true);
       getRequests().then((res) => {
+        console.log(res);
         if (!res.error) {
           const userBookings: Request[] = [];
           for (let i = 0; i < res.requests.length; i++) {
@@ -32,8 +33,8 @@ export default function Bookings(): JSX.Element {
               id: res.requests[i]._id,
               status: res.requests[i].status,
               user: {
-                name: res.requestProfiles[i].name,
-                email: res.requestProfiles[i].email,
+                name: res.requests[i].requester.name,
+                email: res.requests[i].requester.email,
               },
             });
           }

--- a/client/src/pages/ProfileDetails/ProfileDetails.tsx
+++ b/client/src/pages/ProfileDetails/ProfileDetails.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect } from 'react';
 import getProfile from '../../helpers/APICalls/getProfile';
 import Profile from '../../interface/Profile';
 import { useParams } from 'react-router-dom';
+import { useSnackBar } from '../../context/useSnackbarContext';
 
 const mockPhotos = [
   'https://images.pexels.com/photos/3714060/pexels-photo-3714060.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
@@ -16,6 +17,7 @@ const mockPhotos = [
 
 export default function ProfileDetails(): JSX.Element {
   const classes = useStyles();
+  const { updateSnackBarMessage } = useSnackBar();
   const [isMounted, setIsMounted] = useState<boolean>(false);
   const [profile, setProfile] = useState<Profile | undefined>();
 
@@ -27,10 +29,13 @@ export default function ProfileDetails(): JSX.Element {
       getProfile(profileId).then((res) => {
         if (!res.error) {
           setProfile(res.success.profile);
+        } else {
+          console.error(res.error);
+          updateSnackBarMessage('Profile not found');
         }
       });
     }
-  }, [isMounted, profileId]);
+  }, [isMounted, profileId, updateSnackBarMessage]);
 
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
@@ -62,51 +67,51 @@ export default function ProfileDetails(): JSX.Element {
           container
           flexDirection="column"
         >
-          <Box borderRadius={2} className={classes.coverImage}>
-            {profile ? (
-              <AvatarDisplay
-                width={window.innerWidth < 600 ? 100 : 150}
-                height={window.innerWidth < 600 ? 100 : 150}
-                loggedIn
-                user={{ name: profile.name, email: 'example@example.com' }}
-                photoUrl={profile ? profile.photo : ''}
-              />
-            ) : null}
-          </Box>
-          <Box m={windowWidth < 600 ? '1rem 0' : '5rem 0 1rem 0'} textAlign="center">
-            <Typography fontWeight="bold" component="h1" fontSize="1.4rem">
-              {profile ? profile.name : 'No profile found'}
-            </Typography>
-            <Typography fontWeight="bold" color="rgba(0,0,0,0.3)">
-              {profile ? profile.description : null}
-            </Typography>
-          </Box>
-          <Typography
-            margin="auto"
-            mb={4}
-            display="flex"
-            alignItems="center"
-            color="rgba(0,0,0,0.3)"
-            fontWeight="bold"
-            sx={{ textTransform: 'capitalize' }}
-          >
-            {profile ? (
-              <>
-                <LocationOnIcon color="primary" /> &nbsp; {profile.location}
-              </>
-            ) : null}
-          </Typography>
           {profile ? (
-            <Box m={windowWidth < 600 ? `${5} ${4}` : 5}>
-              <Typography mb={1} component="h2" fontSize="1.1rem" fontWeight="bold">
-                About me
+            <>
+              <Box borderRadius={2} className={classes.coverImage}>
+                <AvatarDisplay
+                  width={window.innerWidth < 600 ? 100 : 150}
+                  height={window.innerWidth < 600 ? 100 : 150}
+                  loggedIn
+                  user={{ name: profile.name, email: 'example@example.com' }}
+                  photoUrl={profile.photo}
+                />
+              </Box>
+              <Box m={windowWidth < 600 ? '1rem 0' : '5rem 0 1rem 0'} textAlign="center">
+                <Typography fontWeight="bold" component="h1" fontSize="1.4rem">
+                  {profile.name}
+                </Typography>
+                <Typography fontWeight="bold" color="rgba(0,0,0,0.3)">
+                  {profile.description}
+                </Typography>
+              </Box>
+              <Typography
+                margin="auto"
+                mb={4}
+                display="flex"
+                alignItems="center"
+                color="rgba(0,0,0,0.3)"
+                fontWeight="bold"
+                sx={{ textTransform: 'capitalize' }}
+              >
+                <LocationOnIcon color="primary" /> &nbsp; {profile.location}
               </Typography>
-              <Typography>{profile.aboutMe}</Typography>
-              {mockPhotos.map((item) => (
-                <img key={item} className={classes.listImage} src={item} alt="Pet image" />
-              ))}
-            </Box>
-          ) : null}
+              {profile.aboutMe != '' ? (
+                <Box m={windowWidth < 600 ? `${5} ${4}` : 5}>
+                  <Typography mb={1} component="h2" fontSize="1.1rem" fontWeight="bold">
+                    About me
+                  </Typography>
+                  <Typography mb={4}>{profile.aboutMe}</Typography>
+                  {mockPhotos.map((item) => (
+                    <img key={item} className={classes.listImage} src={item} alt="Pet image" />
+                  ))}
+                </Box>
+              ) : null}
+            </>
+          ) : (
+            'No Profile Found'
+          )}
         </Grid>
         {windowWidth < 1200 ? <Divider sx={{ width: '95%' }} /> : null}
         {profile ? (

--- a/client/src/pages/ProfileDetails/ProfileDetails.tsx
+++ b/client/src/pages/ProfileDetails/ProfileDetails.tsx
@@ -5,27 +5,27 @@ import LocationOnIcon from '@mui/icons-material/LocationOn';
 import RequestForm from './RequestForm/RequestForm';
 import useStyles from './useStyles';
 import { useState, useEffect } from 'react';
-
-const mockProfile = {
-  name: 'Norma Byers',
-  description: 'Loving pet sitter',
-  location: 'Toronto, Ontario',
-  aboutMe:
-    'Animals are my passion! I will look after your pets with loving care. I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, and have owned multiple pets for many years, including numerous rescues. Kindly email, text or call me and I will respond promptly!',
-  payRate: 14,
-  rating: 4,
-};
+import getProfile from '../../helpers/APICalls/getProfile';
+import Profile from '../../interface/Profile';
+import { useParams } from 'react-router-dom';
 
 export default function ProfileDetails(): JSX.Element {
   const classes = useStyles();
   const [isMounted, setIsMounted] = useState<boolean>(false);
-  const [profile, setProfile] = useState(null);
+  const [profile, setProfile] = useState<Profile | undefined>();
+
+  const { profileId } = useParams<{ profileId: string }>();
 
   useEffect(() => {
     if (!isMounted) {
       setIsMounted(true);
+      getProfile(profileId).then((res) => {
+        if (!res.error) {
+          setProfile(res.success.profile);
+        }
+      });
     }
-  }, [isMounted]);
+  }, [isMounted, profileId]);
 
   return (
     <PageContainer>
@@ -52,10 +52,10 @@ export default function ProfileDetails(): JSX.Element {
           </Box>
           <Box m={window.innerWidth < 600 ? '1rem 0' : '5rem 0 1rem 0'} textAlign="center">
             <Typography fontWeight="bold" component="h1" fontSize="1.4rem">
-              {mockProfile.name}
+              {profile ? profile.name : 'No profile found'}
             </Typography>
             <Typography fontWeight="bold" color="rgba(0,0,0,0.3)">
-              {mockProfile.description}
+              {profile ? profile.description : null}
             </Typography>
           </Box>
           <Typography
@@ -66,32 +66,35 @@ export default function ProfileDetails(): JSX.Element {
             color="rgba(0,0,0,0.3)"
             fontSize=".8rem"
             fontWeight="bold"
+            sx={{ textTransform: 'capitalize' }}
           >
-            <LocationOnIcon color="primary" /> &nbsp; {mockProfile.location}
+            <LocationOnIcon color="primary" /> &nbsp; {profile ? profile.location : null}
           </Typography>
           <Box m={window.innerWidth < 600 ? `${5} ${4}` : 5}>
             <Typography mb={1} component="h2" fontSize="1rem" fontWeight="bold">
               About me
             </Typography>
-            <Typography>{mockProfile.aboutMe}</Typography>
+            <Typography>{profile ? profile.aboutMe : null}</Typography>
           </Box>
         </Grid>
         {window.innerWidth < 600 ? <hr style={{ width: '100%' }} /> : null}
-        <Grid
-          xs={12}
-          md={4}
-          item
-          borderRadius={2}
-          boxShadow={window.innerWidth < 600 ? 'none' : 4}
-          container
-          flexDirection="column"
-        >
-          <Typography fontSize="1.2rem" fontWeight="bold" m="3rem auto 1rem auto">
-            ${mockProfile.payRate}/hr
-          </Typography>
-          <Rating sx={{ margin: 'auto' }} value={mockProfile.rating} precision={0.5} />
-          <RequestForm />
-        </Grid>
+        {profile ? (
+          <Grid
+            xs={12}
+            md={4}
+            item
+            borderRadius={2}
+            boxShadow={window.innerWidth < 600 ? 'none' : 4}
+            container
+            flexDirection="column"
+          >
+            <Typography fontSize="1.2rem" fontWeight="bold" m="3rem auto 1rem auto">
+              ${profile.payRate}/hr
+            </Typography>
+            <Rating sx={{ margin: 'auto' }} value={4} precision={0.5} />
+            <RequestForm />
+          </Grid>
+        ) : null}
       </Grid>
     </PageContainer>
   );

--- a/client/src/pages/ProfileDetails/ProfileDetails.tsx
+++ b/client/src/pages/ProfileDetails/ProfileDetails.tsx
@@ -1,4 +1,4 @@
-import { Grid, Box, Typography, Rating, ImageList, ImageListItem } from '@mui/material';
+import { Grid, Box, Typography, Rating } from '@mui/material';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import AvatarDisplay from '../../components/AvatarDisplay/AvatarDisplay';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
@@ -88,7 +88,7 @@ export default function ProfileDetails(): JSX.Element {
                 About me
               </Typography>
               <Typography mb={4}>{profile.aboutMe}</Typography>
-              {mockPhotos.map((item, i) => (
+              {mockPhotos.map((item) => (
                 <img key={item} className={classes.listImage} src={item} alt="Pet image" />
               ))}
             </Box>

--- a/client/src/pages/ProfileDetails/ProfileDetails.tsx
+++ b/client/src/pages/ProfileDetails/ProfileDetails.tsx
@@ -6,7 +6,7 @@ import RequestForm from './RequestForm/RequestForm';
 import useStyles from './useStyles';
 import { useState, useEffect } from 'react';
 import getProfile from '../../helpers/APICalls/getProfile';
-import Profile from '../../interface/Profile';
+import { ProfileDetails as Profile } from '../../interface/Profile';
 import { useParams } from 'react-router-dom';
 import { useSnackBar } from '../../context/useSnackbarContext';
 

--- a/client/src/pages/ProfileDetails/ProfileDetails.tsx
+++ b/client/src/pages/ProfileDetails/ProfileDetails.tsx
@@ -109,7 +109,7 @@ export default function ProfileDetails(): JSX.Element {
               ${profile.payRate}/hr
             </Typography>
             <Rating sx={{ margin: 'auto' }} value={4} precision={0.5} />
-            <RequestForm />
+            <RequestForm profileId={profileId} />
           </Grid>
         ) : null}
       </Grid>

--- a/client/src/pages/ProfileDetails/ProfileDetails.tsx
+++ b/client/src/pages/ProfileDetails/ProfileDetails.tsx
@@ -1,4 +1,4 @@
-import { Grid, Box, Typography, Rating } from '@mui/material';
+import { Grid, Box, Typography, Rating, ImageList, ImageListItem } from '@mui/material';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import AvatarDisplay from '../../components/AvatarDisplay/AvatarDisplay';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
@@ -8,6 +8,11 @@ import { useState, useEffect } from 'react';
 import getProfile from '../../helpers/APICalls/getProfile';
 import Profile from '../../interface/Profile';
 import { useParams } from 'react-router-dom';
+
+const mockPhotos = [
+  'https://images.pexels.com/photos/3714060/pexels-photo-3714060.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+  'https://images.pexels.com/photos/6303371/pexels-photo-6303371.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+];
 
 export default function ProfileDetails(): JSX.Element {
   const classes = useStyles();
@@ -43,12 +48,15 @@ export default function ProfileDetails(): JSX.Element {
           flexDirection="column"
         >
           <Box borderRadius={2} className={classes.coverImage}>
-            <AvatarDisplay
-              width={window.innerWidth < 600 ? 100 : 150}
-              height={window.innerWidth < 600 ? 100 : 150}
-              loggedIn
-              user={{ name: 'example', email: 'example@example.com' }}
-            />
+            {profile ? (
+              <AvatarDisplay
+                width={window.innerWidth < 600 ? 100 : 150}
+                height={window.innerWidth < 600 ? 100 : 150}
+                loggedIn
+                user={{ name: profile.name, email: 'example@example.com' }}
+                photoUrl={profile ? profile.photo : ''}
+              />
+            ) : null}
           </Box>
           <Box m={window.innerWidth < 600 ? '1rem 0' : '5rem 0 1rem 0'} textAlign="center">
             <Typography fontWeight="bold" component="h1" fontSize="1.4rem">
@@ -68,14 +76,23 @@ export default function ProfileDetails(): JSX.Element {
             fontWeight="bold"
             sx={{ textTransform: 'capitalize' }}
           >
-            <LocationOnIcon color="primary" /> &nbsp; {profile ? profile.location : null}
+            {profile ? (
+              <>
+                <LocationOnIcon color="primary" /> &nbsp; {profile.location}
+              </>
+            ) : null}
           </Typography>
-          <Box m={window.innerWidth < 600 ? `${5} ${4}` : 5}>
-            <Typography mb={1} component="h2" fontSize="1rem" fontWeight="bold">
-              About me
-            </Typography>
-            <Typography>{profile ? profile.aboutMe : null}</Typography>
-          </Box>
+          {profile ? (
+            <Box m={window.innerWidth < 600 ? `${5} ${4}` : 5}>
+              <Typography mb={1} component="h2" fontSize="1rem" fontWeight="bold">
+                About me
+              </Typography>
+              <Typography mb={4}>{profile.aboutMe}</Typography>
+              {mockPhotos.map((item, i) => (
+                <img key={item} className={classes.listImage} src={item} alt="Pet image" />
+              ))}
+            </Box>
+          ) : null}
         </Grid>
         {window.innerWidth < 600 ? <hr style={{ width: '100%' }} /> : null}
         {profile ? (

--- a/client/src/pages/ProfileDetails/ProfileDetails.tsx
+++ b/client/src/pages/ProfileDetails/ProfileDetails.tsx
@@ -4,10 +4,7 @@ import AvatarDisplay from '../../components/AvatarDisplay/AvatarDisplay';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import RequestForm from './RequestForm/RequestForm';
 import useStyles from './useStyles';
-import { useAuth } from '../../context/useAuthContext';
-
-const boxShadow =
-  '0px 0px 1.5px rgba(0, 0, 0, 0.006),0px 0px 3.6px rgba(0, 0, 0, 0.009),0px 0px 6.8px rgba(0, 0, 0, 0.011),0px 0px 12px rgba(0, 0, 0, 0.015),0px 0px 22.1px rgba(0, 0, 0, 0.027),0px 0px 48px rgba(0, 0, 0, 0.1)';
+import { useState, useEffect } from 'react';
 
 const mockProfile = {
   name: 'Norma Byers',
@@ -21,6 +18,14 @@ const mockProfile = {
 
 export default function ProfileDetails(): JSX.Element {
   const classes = useStyles();
+  const [isMounted, setIsMounted] = useState<boolean>(false);
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    if (!isMounted) {
+      setIsMounted(true);
+    }
+  }, [isMounted]);
 
   return (
     <PageContainer>

--- a/client/src/pages/ProfileDetails/RequestForm/RequestForm.tsx
+++ b/client/src/pages/ProfileDetails/RequestForm/RequestForm.tsx
@@ -5,12 +5,30 @@ import AdapterDateFns from '@mui/lab/AdapterDateFns';
 import { Typography, Button, CircularProgress } from '@mui/material';
 import FormikDatePicker from '../../../components/FormikDatePicker/FormikDatePicker';
 import useStyles from './useStyles';
+import createRequest from '../../../helpers/APICalls/createRequest';
+import { useSnackBar } from '../../../context/useSnackbarContext';
 
-export default function RequestForm(): JSX.Element {
+export default function RequestForm({ profileId }: { profileId: string }): JSX.Element {
+  const { updateSnackBarMessage } = useSnackBar();
+
   const handleSubmit = (
     { startDate, endDate }: { startDate: Date; endDate: Date },
     { setSubmitting }: FormikHelpers<{ startDate: Date; endDate: Date }>,
   ) => {
+    createRequest(profileId, startDate, endDate).then((data) => {
+      if (data.error) {
+        console.error({ error: data.error.message });
+        updateSnackBarMessage(data.error);
+      } else if (data.success) {
+        updateSnackBarMessage('Request successfully created!');
+      } else {
+        // should not get here from backend but this catch is for an unknown issue
+        console.error({ data });
+
+        setSubmitting(false);
+        updateSnackBarMessage('An unexpected error occurred. Please try again');
+      }
+    });
     setSubmitting(false);
   };
 

--- a/client/src/pages/ProfileDetails/useStyles.ts
+++ b/client/src/pages/ProfileDetails/useStyles.ts
@@ -21,6 +21,12 @@ const useStyles = makeStyles((theme: Theme) => ({
       },
     },
   },
+  listImage: {
+    width: 125,
+    height: 125,
+    borderRadius: 10,
+    marginRight: 20,
+  },
 }));
 
 export default useStyles;

--- a/server/controllers/profile.js
+++ b/server/controllers/profile.js
@@ -39,3 +39,21 @@ exports.loadProfile = asyncHandler(async (req, res, next) => {
     },
   });
 });
+
+// @route GET /profile/load/:profileId
+// @route Get user profile data based on id
+// @access Public
+exports.loadProfileById = asyncHandler(async (req, res, next) => {
+  const profile = await Profile.findById(params.profileId)
+
+  if (!profile || !profile.isSitter) {
+    res.status(403);
+    throw new Error ("Invalid profile")
+  }
+
+  res.status(200).json({
+    success: {
+      profile
+    }
+  })
+})

--- a/server/controllers/profile.js
+++ b/server/controllers/profile.js
@@ -44,8 +44,7 @@ exports.loadProfile = asyncHandler(async (req, res, next) => {
 // @route Get user profile data based on id
 // @access Public
 exports.loadProfileById = asyncHandler(async (req, res, next) => {
-  const profile = await Profile.findById(params.profileId)
-
+  const profile = await Profile.findById(req.params.profileId)
   if (!profile || !profile.isSitter) {
     res.status(403);
     throw new Error ("Invalid profile")

--- a/server/controllers/request.js
+++ b/server/controllers/request.js
@@ -19,6 +19,9 @@ exports.createRequest = asyncHandler(async (req, res, next) => {
         }
       }
     })
+  } else {
+    res.status(404);
+    throw new Error("Request does not exist")
   }
 });
 

--- a/server/controllers/request.js
+++ b/server/controllers/request.js
@@ -7,8 +7,9 @@ const User = require("../models/User");
 // @desc Create new request
 // @access Public
 exports.createRequest = asyncHandler(async (req, res, next) => {
-  const { requester, sitter, startDate, endDate } = req.body
-  const request = await Request.create({requester, sitter, startDate, endDate});
+  const profileId = await Profile.findOne({"userId": req.user.id})
+  const { sitter, startDate, endDate } = req.body
+  const request = await Request.create({ requester: profileId, sitter, startDate, endDate });
 
   if (request) {
     res.status(200).json({

--- a/server/controllers/request.js
+++ b/server/controllers/request.js
@@ -36,7 +36,7 @@ exports.editRequest = asyncHandler(async (req, res, next) => {
     throw new Error("Request doesn't exist");
   }
   const profile = await Profile.findOne({'userId': req.user.id})
-  if (request.sitter == profile._id) {
+  if (request.sitter.toString() == profile._id.toString()) {
     const { status } = req.body
     request.set('status', status)
     const updatedRequest = await request.save();

--- a/server/controllers/request.js
+++ b/server/controllers/request.js
@@ -36,7 +36,7 @@ exports.editRequest = asyncHandler(async (req, res, next) => {
     throw new Error("Request doesn't exist");
   }
   const profile = await Profile.findOne({'userId': req.user.id})
-  if (profile.isSitter) {
+  if (request.sitter == profile._id) {
     const { status } = req.body
     request.set('status', status)
     const updatedRequest = await request.save();
@@ -57,12 +57,8 @@ exports.editRequest = asyncHandler(async (req, res, next) => {
 exports.getUserRequests = asyncHandler(async (req, res, next) => {
   const profile = await Profile.findOne({'userId': req.user.id})
   if (profile.isSitter) {
-    const requests = await Request.where('sitter', profile._id);
-    const requestProfiles = []
-    for (let i = 0; i < requests.length; i++) {
-      requestProfiles.push(await Profile.findById(requests[i].requester))
-    }
-    res.status(200).json({ requests: requests, requestProfiles: requestProfiles })
+    const requests = await Request.where('sitter', profile._id).populate('requester');
+    res.status(200).json({ requests: requests })
   } else {
     res.status(403);
     throw new Error("You are not authorized to perform this operation");

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -38,6 +38,16 @@ const profileSchema = new mongoose.Schema({
     type: Boolean,
     default: false,
   },
+  payRate: {
+    type: String,
+    default: "",
+  },
+  location: {
+    type: String,
+    default: "",
+    lowercase: true,
+    trim: true
+  }
 });
 
 module.exports = Profile = mongoose.model("Profile", profileSchema);

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -14,6 +14,10 @@ const profileSchema = new mongoose.Schema({
     type: String,
     default: "",
   },
+  aboutMe: {
+    type: String,
+    default: "",
+  },
   gender: {
     type: String,
     default: "none",

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -4,10 +4,13 @@ const protect = require('../middleware/auth');
 const {
   editProfile,
   loadProfile,
+  loadProfileById
 } = require('../controllers/profile');
 
 router.route('/edit').put(protect, editProfile);
 
 router.route('/load').get(protect, loadProfile);
+
+router.route('/load/:profileId').get(protect, loadProfileById);
 
 module.exports = router;

--- a/server/validate.js
+++ b/server/validate.js
@@ -30,15 +30,3 @@ exports.validateLogin = [
     next();
   }
 ];
-
-exports.validateUserTypeQuery = [
-  query("userType", "User type must either be requester or sitter").isIn(["requester", "sitter"]),
-  query("userType", "User type must be specified").not().isEmpty(),
-  (req, res, next) => {
-    const errors = validationResult(req);
-
-    if (!errors.isEmpty())
-      return res.status(400).json({ errors: errors.array() });
-    next();
-  }
-]


### PR DESCRIPTION
### What this PR does:
- Hooks the profile details page to the backend.
- Profile is retrieved based on id passed in params /profile/:id
- Requests can be sent via the request form.

### Screenshots / Video:
![image](https://user-images.githubusercontent.com/34494229/150627356-ac20ac92-b085-4714-ae5c-637ffd2c930d.png)
![image](https://user-images.githubusercontent.com/34494229/150627424-f9984a79-7e9f-4d62-98f7-b247589e6cc8.png)
![image](https://user-images.githubusercontent.com/34494229/150627475-f630b433-cdf9-4425-ab7f-7d8256725fb9.png)


### Any information needed to test this feature:
- Sign up as a new user to populate the necessary fields. Some can be edited in the profile settings page, others are not implemented and must be changed directly in the database or left as empty strings.
- Make sure you have a valid Profile to retrieve, in it you will want: name, photo (url), location, description, aboutMe, isSitter, and payRate. Photo is the most optional one (as it has a placeholder), the others will just default to empty strings. isSitter must be true or the page won't load the profile at all.

- Enter in a valid date range into the request form and submit. You should see a message that it was successful. Check your server to ensure successful creation.

### Any issues with the current functionality:
- The extra images are not currently implemented in the model, thus mock images will be used until they are there and uploadable. It should be a very easy integration once it is done.
- Not all values can be set in the settings, so naturally creating and editing a profile will not show all available information (although you can still send requests).
- Natural navigation to the profile details is not yet implemented. We currently must enter the profile id manually into the url.

closes #35 