### PR TITLE
Adding Payment Controllers and Payment Profile UI

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,8 @@
     "@mui/lab": "^5.0.0-alpha.55",
     "@mui/material": "^5.1.1",
     "@mui/styles": "^5.1.1",
+    "@stripe/react-stripe-js": "^1.7.0",
+    "@stripe/stripe-js": "^1.22.0",
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",

--- a/client/src/components/PaymentCard/PaymentCard.tsx
+++ b/client/src/components/PaymentCard/PaymentCard.tsx
@@ -1,0 +1,61 @@
+import { Box, Typography, Checkbox, Avatar } from '@mui/material';
+import { useStyles } from './useStyles';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CircleOutlinedIcon from '@mui/icons-material/CircleOutlined';
+import { useEffect, useState } from 'react';
+
+interface PaymentCardProps {
+  brand: string;
+  isDefault: boolean;
+  last4: string;
+  expireMonth: number;
+  expireYear: number;
+  cardHolderName: string | null;
+}
+
+const PaymentCard: React.FC<PaymentCardProps> = ({
+  brand,
+  isDefault,
+  last4,
+  expireMonth,
+  expireYear,
+  cardHolderName,
+}) => {
+  cardHolderName = cardHolderName || '';
+  const classes = useStyles();
+  const [cardTypeLogo, setCardTypeLogo] = useState<string>();
+  useEffect(() => {
+    if (brand === 'visa') {
+      setCardTypeLogo('https://logos-world.net/wp-content/uploads/2020/04/Visa-Logo.png');
+    } else if (brand === 'mastercard') {
+      setCardTypeLogo(
+        'https://brand.mastercard.com/content/dam/mccom/brandcenter/thumbnails/mastercard_vrt_rev_92px_2x.png',
+      );
+    }
+  }, [brand]);
+  return (
+    <Box
+      marginRight={5}
+      marginBottom={5}
+      display="flex"
+      flexDirection="column"
+      justifyContent="space-between"
+      className={classes.root}
+    >
+      <Box display="flex" justifyContent="space-between">
+        <Avatar sx={{ width: 75, height: 40 }} variant="square" src={cardTypeLogo} />
+        <Checkbox color="primary" checked={isDefault} icon={<CircleOutlinedIcon />} checkedIcon={<CheckCircleIcon />} />
+      </Box>
+      <Box>
+        <Typography fontSize="large" fontWeight="bold">
+          **** **** **** {last4}
+        </Typography>
+        <Typography fontSize="small">
+          Exp. Date {expireMonth}/{expireYear}
+        </Typography>
+      </Box>
+      <Typography fontWeight="bold">{cardHolderName}</Typography>
+    </Box>
+  );
+};
+export default PaymentCard;

--- a/client/src/components/PaymentCard/useStyles.ts
+++ b/client/src/components/PaymentCard/useStyles.ts
@@ -1,0 +1,11 @@
+import { makeStyles } from '@mui/styles';
+
+export const useStyles = makeStyles(() => ({
+  root: {
+    height: 200,
+    width: 350,
+    padding: 20,
+    borderRadius: 8,
+    border: '1px solid #dbdbdb',
+  },
+}));

--- a/client/src/components/PaymentSetup/PaymentSetupForm.tsx
+++ b/client/src/components/PaymentSetup/PaymentSetupForm.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { useStripe, useElements, PaymentElement } from '@stripe/react-stripe-js';
+import { Box, Button } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles(() => ({
+  button: {
+    height: 70,
+  },
+}));
+const PaymentSetupForm: React.FC = () => {
+  const stripe = useStripe();
+  const elements = useElements();
+  const classes = useStyles();
+
+  const [errorMessage, setErrorMessage] = useState<string | undefined>('');
+
+  const handleSubmit = async (event: any) => {
+    event.preventDefault();
+    if (!stripe || !elements) {
+      return;
+    }
+    const { error } = await stripe.confirmSetup({
+      elements,
+      confirmParams: {
+        return_url: 'http://localhost:3000/profile/settings/payment-methods',
+      },
+    });
+
+    if (error) {
+      setErrorMessage(error.message);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <PaymentElement />
+      <Box py={4}>
+        <Button type="submit" disabled={!stripe} variant="outlined" size="large" className={classes.button}>
+          Submit
+        </Button>
+      </Box>
+      {errorMessage && <div>{errorMessage}</div>}
+    </form>
+  );
+};
+
+export default PaymentSetupForm;

--- a/client/src/helpers/APICalls/payment.ts
+++ b/client/src/helpers/APICalls/payment.ts
@@ -1,0 +1,50 @@
+import { FetchOptions } from '../../interface/FetchOptions';
+interface ClientSecretAPIData {
+  success?: {
+    client_secret?: string;
+  };
+  error?: { message: string };
+}
+export interface Card {
+  brand: string;
+  exp_month: number;
+  exp_year: number;
+  last4: string;
+  name: string | null;
+  country: string;
+}
+export interface PaymentMethod {
+  id: string;
+  customer: string;
+  type: string;
+  card: Card;
+}
+interface SavedCardsAPIData {
+  success?: {
+    payment_methods: PaymentMethod[];
+  };
+  error?: { message: string };
+}
+export const fetchClientSecret = async (): Promise<ClientSecretAPIData> => {
+  const fetchOptions: FetchOptions = {
+    method: 'GET',
+    credentials: 'include',
+  };
+  return await fetch(`/payments/secret`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export const fetchSavedCards = async (): Promise<SavedCardsAPIData> => {
+  const fetchOptions: FetchOptions = {
+    method: 'GET',
+    credentials: 'include',
+  };
+  return await fetch(`/payments/saved-cards`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};

--- a/client/src/pages/Settings/Payment/Payment.tsx
+++ b/client/src/pages/Settings/Payment/Payment.tsx
@@ -1,0 +1,130 @@
+import React, { useState, useEffect } from 'react';
+import { Elements } from '@stripe/react-stripe-js';
+import { loadStripe } from '@stripe/stripe-js';
+import { fetchClientSecret, fetchSavedCards, PaymentMethod } from '../../../helpers/APICalls/payment';
+import { useSnackBar } from '../../../context/useSnackbarContext';
+
+import { makeStyles } from '@mui/styles';
+import { Box, Button, Typography } from '@mui/material';
+import SettingHeader from '../../../components/SettingsHeader/SettingsHeader';
+
+import PaymentCard from '../../../components/PaymentCard/PaymentCard';
+import PaymentSetupForm from '../../../components/PaymentSetup/PaymentSetupForm';
+import { CircularProgress } from '@mui/material';
+
+const stripePromise = loadStripe(
+  'pk_test_51KKJPUHik32C4EVUqXN1YLxBPjMbWS01IaIRIUAnR2bKEz730V4UY0bGo89Vgd4WjF95XqFIbf7qHUFuRBmXn6Z700WymMSUcv',
+);
+const useStyles = makeStyles({
+  root: {
+    '& .MuiButton-root': {
+      textTransform: 'none',
+    },
+  },
+  button: {
+    height: 70,
+  },
+});
+interface PaymentProps {
+  header: string;
+}
+const Payment: React.FC<PaymentProps> = ({ header }) => {
+  const classes = useStyles();
+  const { updateSnackBarMessage } = useSnackBar();
+
+  const [clientSecret, setClientSecret] = useState<string>('');
+  const [paymentMethods, setPaymentMethods] = useState<Array<PaymentMethod>>();
+  const [isAddCard, setIsAddCard] = useState<boolean>(false);
+
+  const options = {
+    clientSecret,
+    appearance: {},
+  };
+  useEffect(() => {
+    fetchSavedCards()
+      .then((data) => {
+        if (data.error) {
+          updateSnackBarMessage(data.error.message);
+        } else if (data.success) {
+          setPaymentMethods(data.success.payment_methods);
+        }
+      })
+      .catch((err) => {
+        updateSnackBarMessage(err);
+      });
+
+    fetchClientSecret()
+      .then((data) => {
+        if (data.error) {
+          updateSnackBarMessage(data.error.message);
+        } else if (data.success) {
+          setClientSecret(data.success?.client_secret || '');
+        }
+      })
+      .catch((err) => {
+        updateSnackBarMessage(err);
+      });
+  }, [updateSnackBarMessage]);
+  if (clientSecret === '') {
+    return <CircularProgress />;
+  }
+
+  const addNewPaymentProfileHandler = () => {
+    setIsAddCard(true);
+  };
+  const cancleAddPaymentProfileHandler = () => {
+    setIsAddCard(false);
+  };
+
+  return (
+    <Box
+      sx={{
+        margin: '0 auto',
+      }}
+      minHeight="70vh"
+      display="flex"
+      flexDirection="column"
+      justifyContent="flex-start"
+    >
+      <SettingHeader header={header} />
+      <Box height="70vh" className={classes.root}>
+        {isAddCard ? (
+          <Elements stripe={stripePromise} options={options}>
+            <PaymentSetupForm />
+            <Button variant="outlined" size="large" onClick={cancleAddPaymentProfileHandler} className={classes.button}>
+              Go Back
+            </Button>
+          </Elements>
+        ) : (
+          <Box>
+            <Typography fontSize={18} fontWeight="light">
+              Saved Payment Profiles:
+            </Typography>
+            <Box mt={5} display="flex" justifyContent="flext-start" width="100%" flexWrap="wrap">
+              {paymentMethods?.map((method, index) => {
+                return (
+                  <PaymentCard
+                    key={method?.id}
+                    isDefault={index === 0}
+                    brand={method?.card.brand}
+                    last4={method?.card?.last4}
+                    expireMonth={method?.card?.exp_month}
+                    expireYear={method?.card?.exp_year}
+                    cardHolderName={method?.card?.name}
+                  />
+                );
+              })}
+            </Box>
+            <Box py={4}>
+              <Button variant="outlined" size="large" onClick={addNewPaymentProfileHandler} className={classes.button}>
+                Add new payment profile
+              </Button>
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default Payment;

--- a/client/src/pages/Settings/Settings.tsx
+++ b/client/src/pages/Settings/Settings.tsx
@@ -8,6 +8,7 @@ import SettingsWrapper from '../../components/SettingsWrapper/SettingsWrapper';
 import EditProfile from './EditProfile/EditProfile';
 import SettingHeader from '../../components/SettingsHeader/SettingsHeader';
 import ProfilePhoto from './ProfilePhoto/ProfilePhoto';
+import Payment from './Payment/Payment';
 
 const settingsMenu = [
   {
@@ -28,7 +29,7 @@ const settingsMenu = [
   {
     name: 'Payment methods',
     to: '/profile/settings/payment-methods',
-    component: <SettingHeader header="Payment Methods" />,
+    component: <Payment header="Payment Methods" />,
   },
 ];
 

--- a/server/app.js
+++ b/server/app.js
@@ -13,25 +13,41 @@ const logger = require("morgan");
 const authRouter = require("./routes/auth");
 const userRouter = require("./routes/user");
 const profileRouter = require("./routes/profile");
-const uploadRouter = require("./routes/upload");
-const deleteRouter = require("./routes/delete");
 const availabilityRouter = require("./routes/availability");
 const paymentsRoute = require("./routes/payment");
+const notificationRouter = require("./routes/notification");
+const conversationRouter = require("./routes/conversation");
+const requestRouter = require("./routes/request");
+const uploadRouter = require("./routes/upload");
+const deleteRouter = require("./routes/delete");
+const reviewRouter = require("./routes/review");
+const cors = require("cors");
 
 const { json, urlencoded } = express;
 
 connectDB();
+
 const app = express();
+app.use(
+  cors({
+    credentials: true,
+    origin: function (origin, callback) {
+      console.log(origin);
+      if (process.env.ALLOWED_ORIGINS.indexOf(origin) !== -1 || !origin) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
+  })
+);
+
 const server = http.createServer(app);
 
 const io = socketio(server, {
   cors: {
     origin: "*",
   },
-});
-
-io.on("connection", (socket) => {
-  console.log("connected");
 });
 
 if (process.env.NODE_ENV === "development") {
@@ -54,17 +70,20 @@ app.use((req, res, next) => {
 app.use("/auth", authRouter);
 app.use("/users", userRouter);
 app.use("/profile", profileRouter);
+app.use("/notifications", notificationRouter);
+app.use("/conversations", conversationRouter);
+app.use("/requests", requestRouter);
 app.use("/upload", uploadRouter);
 app.use("/delete", deleteRouter);
 app.use("/availability", availabilityRouter);
-app.use("/payments", paymentsRoute);
+app.use("/reviews", reviewRouter);
 
 if (process.env.NODE_ENV === "production") {
-  app.use(express.static(path.join(__dirname, "/client/build")));
-
-  app.get("*", (req, res) =>
-    res.sendFile(path.resolve(__dirname), "client", "build", "index.html")
-  );
+  app.use(express.static(path.join(__dirname, "/../client/build")));
+  app.get("*", (req, res, next) => {
+    res.sendFile(path.resolve(__dirname, "/../client", "build", "index.html"));
+  });
+  server.listen(process.env.PORT);
 } else {
   app.get("/", (req, res) => {
     res.send("API is running");

--- a/server/app.js
+++ b/server/app.js
@@ -16,6 +16,7 @@ const profileRouter = require("./routes/profile");
 const uploadRouter = require("./routes/upload");
 const deleteRouter = require("./routes/delete");
 const availabilityRouter = require("./routes/availability");
+const paymentsRoute = require("./routes/payment");
 
 const { json, urlencoded } = express;
 
@@ -56,6 +57,7 @@ app.use("/profile", profileRouter);
 app.use("/upload", uploadRouter);
 app.use("/delete", deleteRouter);
 app.use("/availability", availabilityRouter);
+app.use("/payments", paymentsRoute);
 
 if (process.env.NODE_ENV === "production") {
   app.use(express.static(path.join(__dirname, "/client/build")));

--- a/server/controllers/payment.js
+++ b/server/controllers/payment.js
@@ -1,0 +1,44 @@
+const asyncHandler = require("express-async-handler");
+const stripe = require("stripe")(process.env.STRIPE_SK_KEY);
+const User = require("../models/User");
+
+const createOrRetrieveStripeCustomer = async (userId) => {
+  const user = await User.findById(userId);
+  if (!user) {
+    throw new Error("User not found!!");
+  }
+  if (user.stripeCustomerId !== "") {
+    return await stripe.customers.retrieve(user.stripeCustomerId);
+  }
+  const customer = await stripe.customers.create({
+    email: user.email,
+    name: user.name,
+  });
+  if (!customer) {
+    throw new Error("Unable to create payment account!!");
+  }
+  user.set({ stripeCustomerId: customer.id });
+  const saveUser = await user.save();
+  if (!saveUser) {
+    throw new Error("Unable to link payment account to user account!!");
+  }
+  return customer;
+};
+
+exports.getClientSecret = asyncHandler(async (req, res, next) => {
+  const customer = await createOrRetrieveStripeCustomer(req.user.id);
+  if (!customer) {
+    res.status(400);
+    throw new Error("Unable to create customer");
+  }
+  const setupIntent = await stripe.setupIntents.create({
+    customer: customer.id,
+    payment_method_types: ["card"],
+  });
+  if (!setupIntent) {
+    res.status(404);
+    throw new Error("Unable proccess payment setup");
+  }
+  res.status(200);
+  res.send({ client_secret: setupIntent.client_secret });
+});

--- a/server/controllers/payment.js
+++ b/server/controllers/payment.js
@@ -87,7 +87,7 @@ exports.chargeSavedPaymentMethod = asyncHandler(async (req, res, next) => {
     res.status(400);
     throw new Error("Please provide a request id to process payment");
   }
-  const request = await Request.findById(requestId);
+  const request = await Request.findById(requestId).populate('requester');
   if (!request) {
     res.status(404);
     throw new Error("Request Not Found!!");

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -5,21 +5,25 @@ const userSchema = new mongoose.Schema({
   name: {
     type: String,
     required: true,
-    unique: true
+    unique: true,
   },
   email: {
     type: String,
     required: true,
-    unique: true
+    unique: true,
   },
   password: {
     type: String,
-    required: true
+    required: true,
   },
   registerDate: {
     type: Date,
-    default: Date.now
-  }
+    default: Date.now,
+  },
+  stripeCustomerId: {
+    type: String,
+    default: "",
+  },
 });
 
 userSchema.methods.matchPassword = async function (enteredPassword) {

--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+const protect = require("../middleware/auth");
+const {
+  getClientSecret,
+  getListOfPaymentSources,
+  chargeSavedPaymentMethod,
+} = require("../controllers/payment");
+
+router.route("/secret").get(protect, getClientSecret);
+router.route("/saved-cards").get(protect, getListOfPaymentSources);
+router.route("/charge-default-card").post(protect, chargeSavedPaymentMethod);
+
+module.exports = router;


### PR DESCRIPTION
### What this PR does (required):
- Creates controller to get list of payment methods for user
- Creates controller to get client secret to securely add card payment method 
- Creates controller to charge owner (requester) of pet sitting request
- Adds routes for payment controllers
- Creates Profile Payment page

### Screenshots/videos
![Profile Payment Methods Settings](https://user-images.githubusercontent.com/23405638/151184408-b6d0b62c-992f-48d8-b154-66a7eb514d27.PNG)

### Any information needed to test this feature (required):
- Login/Register
- Navigate to profile settings and payment methods
- The page should show the current saved payment methods
- click on 'Add new profile payment' will open form to enter and submit card details 
- Fetch client secret by GET `/payments/secret`
- Fetch list of cards by GET `/payments/saved-cards`
- Charge amount to requester by POST `/payments/charge-default-card` and provide request id in body of request

### Any issues with the current functionality (optional):
- The Endpoint are test through third party API platform `Postman`. Needs to integrate with front end to actual see the results 